### PR TITLE
[Fix] First chunk of dictionary was inserted twice

### DIFF
--- a/geetools/batch/featurecollection.py
+++ b/geetools/batch/featurecollection.py
@@ -198,7 +198,7 @@ def toDict(collection, split_at=4000):
     content = col.getInfo()
     feats = content['features']
 
-    for i in range(0, collections_size):
+    for i in range(1, collections_size):
         c = ee.FeatureCollection(collections.get(i))
         content_c = c.getInfo()
         feats_c = content_c['features']


### PR DESCRIPTION
Hi,

I found that when a feature collection size exceeds 5000, the 'chunking' mechanism adds twice the first chunk. 

Best and thanks for the great work!

Hubert