### PR TITLE
fix: extract DateRange from the root init for backward compatibility

### DIFF
--- a/docs/usage/layout.rst
+++ b/docs/usage/layout.rst
@@ -94,6 +94,12 @@ helper
 ee.DateRange
 ^^^^^^^^^^^^
 
+As reported in https://github.com/gee-community/geetools/issues/206, this object cannot be extended before the API of Earth Enfine is initialized. So to use the following methods, you will be forced to manually import the following:
+
+.. code-block:: python
+
+    from geetools.DateRange import DateRangeAccessor
+
 Extra operations
 ################
 

--- a/geetools/DateRange/__init__.py
+++ b/geetools/DateRange/__init__.py
@@ -1,4 +1,15 @@
-"""Extra tools for the ``ee.DateRange`` class."""
+"""Extra tools for the ``ee.DateRange`` class.
+
+.. warning::
+
+    As reported in https://github.com/gee-community/geetools/issues/206, for user using ``earthengine-api<=0.1.388``
+    this object cannot be extended before the API of Earth Enfine is initialized. So to use the
+    following methods, you will be forced to manually import the following:
+
+    .. code-block:: python
+
+        from geetools.DateRange import DateRangeAccessor
+"""
 from __future__ import annotations
 
 import ee

--- a/geetools/__init__.py
+++ b/geetools/__init__.py
@@ -48,8 +48,11 @@ from .Initialize import InitializeAccessor
 from .Authenticate import AuthenticateAccessor
 
 # Array cannot be imported directly in geetools prior to Initialisation
-# waiting for a fix in https://github.com/gee-community/geetools/issues/173
-# from .Array import Array
+# waiting for a fix in
+# https://github.com/gee-community/geetools/issues/173
+# https://github.com/gee-community/geetools/issues/206
+# from .Array import ArrayAccessor
+# from .DateRange import DateRangeAccessor
 
 
 __title__ = "geetools"

--- a/tests/test_DateRange.py
+++ b/tests/test_DateRange.py
@@ -3,6 +3,7 @@ import ee
 import pytest
 
 import geetools
+from geetools.DateRange import DateRangeAccessor  # noqa: F401
 
 
 class TestSplit:


### PR DESCRIPTION
Fix #206 