### PR TITLE
fix: prevent Asset to be absolute

### DIFF
--- a/geetools/Asset/__init__.py
+++ b/geetools/Asset/__init__.py
@@ -18,8 +18,13 @@ class Asset(YamlAble):
     """An Asset management class mimicking the ``pathlib.Path`` class behaviour."""
 
     def __init__(self, *args):
-        """Initialize the Asset class."""
+        """Initialize the Asset class.
+
+        .. note::
+            An asset cannot be an absolute path like in a normal filesystem and thus any trailing "/" will be removed.
+        """
         self._path = args[0]._path if isinstance(args[0], Asset) else PurePosixPath(*args)
+        self._path = PurePosixPath(str(self._path)[1:]) if self._path.is_absolute() else self._path
 
     def __str__(self):
         """Transform the asset id to a string."""

--- a/tests/test_Asset.py
+++ b/tests/test_Asset.py
@@ -18,6 +18,10 @@ class TestConstructors:
         asset = ee.Asset.home()
         assert asset == f"projects/{EARTHENGINE_PROJECT}/assets"
 
+    def test_not_absolute(self):
+        asset = ee.Asset("/projects/foo/bar")
+        assert asset == "projects/foo/bar"
+
 
 class TestStr:
     """Test the to_string method."""


### PR DESCRIPTION
Fix #231 
As mentioned in the issue a user should not be able to register an absolute path as it has no GEE meaning. 
To prevent that any trailing "/" will be removed upon Asset init.