### PR TITLE
fix: save the project in the Initialize extension

### DIFF
--- a/docs/usage/layout.rst
+++ b/docs/usage/layout.rst
@@ -262,6 +262,7 @@ ee.Initialize
 ^^^^^^^^^^^^^
 
 - :py:meth:`ee.Initialize.geetools.from_user <geetools.Initialize.InitializeAccessor.from_user>`: :docstring:`geetools.InitializeAccessor.from_user`
+- :py:meth:`ee.Initialize.geetools.project_id <geetools.Initialize.InitializeAccessor.project_id>`: :docstring:`geetools.InitializeAccessor.project_id`
 
 ee.Join
 ^^^^^^^

--- a/geetools/Initialize/__init__.py
+++ b/geetools/Initialize/__init__.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Optional
 
 import ee
 from google.oauth2.credentials import Credentials
 
 from geetools.accessors import register_function_accessor
+
+_project_id: Optional[str] = None
+"The project Id used by the current user."
 
 
 @register_function_accessor(ee.Initialize, "geetools")
@@ -20,7 +23,7 @@ class InitializeAccessor:
         self._obj = obj
 
     @staticmethod
-    def from_user(name: str = "", credential_pathname: str = "") -> None:
+    def from_user(name: str = "", credential_pathname: str = "", project: str = "") -> None:
         """Initialize Earthengine API using a specific user.
 
         Equivalent to the ``ee.initialize`` function but with a specific credential file stored in the machine by the ``ee.Authenticate.to_user`` function.
@@ -28,6 +31,7 @@ class InitializeAccessor:
         Args:
             name: The name of the user as saved when created. use default if not set
             credential_pathname: The path to the folder where the credentials are stored. If not set, it uses the default path
+            project: The project_id to use. If not set, it uses the default project_id of the saved credentials.
 
         Example:
             .. code-block:: python
@@ -40,25 +44,54 @@ class InitializeAccessor:
                 # check that GEE is connected
                 ee.Number(1).getInfo()
         """
+        # gather global variable to be modified
+        global _project_id
+
+        # set the user profile information
         name = f"credentials{name}"
         credential_pathname = credential_pathname or ee.oauth.get_credentials_path()
-        credential_path = Path(credential_pathname).parent
+        credential_folder = Path(credential_pathname).parent
+        credential_path = credential_folder / name
 
-        try:
-            tokens = json.loads((credential_path / name).read_text())
-            refresh_token = tokens["refresh_token"]
-            client_id = tokens["client_id"]
-            client_secret = tokens["client_secret"]
-            credentials = Credentials(
-                None,
-                refresh_token=refresh_token,
-                token_uri=ee.oauth.TOKEN_URI,
-                client_id=client_id,
-                client_secret=client_secret,
-                scopes=ee.oauth.SCOPES,
-            )
-        except Exception:
+        # check if the user exists
+        if not credential_path.exists():
             msg = "Please register this user first by using geetools.User.create first"
             raise ee.EEException(msg)
 
+        # Set the credential object and Init GEE API
+        tokens = json.loads((credential_path / name).read_text())
+        credentials = Credentials(
+            None,
+            refresh_token=tokens["refresh_token"],
+            token_uri=ee.oauth.TOKEN_URI,
+            client_id=tokens["client_id"],
+            client_secret=tokens["client_secret"],
+            scopes=ee.oauth.SCOPES,
+        )
         ee.Initialize(credentials)
+
+        # save the project_id in a dedicated global variable as it's not saved
+        # from GEE side
+        _project_id = project or tokens["project_id"]
+
+
+@register_function_accessor(ee.Initialize, "geetools")
+def project_id() -> str:
+    """Get the project_id of the current account.
+
+    Returns:
+        The project_id of the connected profile
+
+    Raises:
+        RuntimeError: If the account is not initialized.
+
+    Examples:
+        .. code-block::
+
+            import ee, geetools
+
+            ee.Initialize.geetools.project_id()
+    """
+    if _project_id is None:
+        raise RuntimeError("The GEE account is not initialized")
+    return _project_id


### PR DESCRIPTION
Update the initialize script to make it compatible with the new GEE init process and save the project_id in the extension