### PR TITLE
fix fullLike (again)

### DIFF
--- a/geetools/Image/__init__.py
+++ b/geetools/Image/__init__.py
@@ -527,8 +527,9 @@ class ImageAccessor:
         image = ee.Algorithms.If(copyProperties, withProperties, image)
         # handle mask
         withMask = ee.Image(image).updateMask(self._obj.mask())
-        image = ee.Algorithms.If(keepMask, withMask, image)
-        return ee.Image(image)
+        image = ee.Image(ee.Algorithms.If(keepMask, withMask, image))
+        # handle band types
+        return ee.Image(image.cast(self._obj.bandTypes()))
 
     def reduceBands(
         self,


### PR DESCRIPTION
I tried to use an `ee.Image` created by `ee.Image.geetools.fullLike` (with the latest modifications) inside an `ee.ImageCollection` and got an error complaining about "not being an homogeneous" collection. This PR solves that issue.