### PR TITLE
feat: add a setProperty method to the Asset object

### DIFF
--- a/docs/usage/layout.rst
+++ b/docs/usage/layout.rst
@@ -371,6 +371,7 @@ Operation
 - :py:meth:`ee.Asset.copy <geetools.Asset.Asset.copy>`: :docstring:`geetools.Asset.copy`
 - :py:meth:`ee.Asset.glob <geetools.Asset.Asset.glob>`: :docstring:`geetools.Asset.glob`
 - :py:meth:`ee.Asset.rglob <geetools.Asset.Asset.rglob>`: :docstring:`geetools.Asset.rglob`
+- :py:meth:`ee.Asset.setProperties <geetools.Asset.Asset.setProperties>`: :docstring:`geetools.Asset.setProperties`
 
 Property
 ########

--- a/geetools/Asset/__init__.py
+++ b/geetools/Asset/__init__.py
@@ -748,3 +748,18 @@ class Asset:
             desc = re.sub(pattern, rep, desc)  # type: ignore
 
         return desc[:100]
+
+    def setProperties(self, **kwargs) -> ee.Asset:
+        """Set properties of the asset.
+
+        Args:
+            **kwargs: The properties to set key, value pairs
+
+        Examples:
+            .. code-block:: python
+
+                asset = ee.Asset("projects/ee-geetools/assets/folder/image")
+                asset.setProperties(description="new_description")
+        """
+        ee.data.setAssetProperties(self.as_posix(), kwargs)
+        return self

--- a/tests/test_Asset.py
+++ b/tests/test_Asset.py
@@ -345,3 +345,12 @@ class TestServerMethods:
         asset.move(new_asset)
         assert asset.exists() is False
         assert new_asset.exists() is True
+
+
+class TestSetProperties:
+    """Test the ``set_properties`` method."""
+
+    def test_set_properties(self, gee_test_folder):
+        asset = ee.Asset(gee_test_folder) / "folder" / "image"
+        asset.setProperties(foo="bar")
+        assert ee.Image(asset.as_posix()).get("foo").getInfo() == "bar"


### PR DESCRIPTION
Fix #274 

The side step from the original vanilla method is that I'm using kwargs instead of a dict. 
My reasoning is that a dict is not the easiest to write in Python linted code as you'll get a double indentation for nothing. 