### PR TITLE
fix: use the fuly static definition of GEE

### DIFF
--- a/docs/usage/layout.rst
+++ b/docs/usage/layout.rst
@@ -20,12 +20,6 @@ Earth Engine classes
 ee.Array
 ^^^^^^^^
 
-As reported in https://github.com/gee-community/geetools/issues/173, this object cannot be extended before the API of Earth Enfine is initialized. So to use the following methods, you will be forced to manually import the following:
-
-.. code-block:: python
-
-    from geetools.Array import ArrayAccessor
-
 constructor
 ###########
 
@@ -93,12 +87,6 @@ helper
 
 ee.DateRange
 ^^^^^^^^^^^^
-
-As reported in https://github.com/gee-community/geetools/issues/206, this object cannot be extended before the API of Earth Enfine is initialized. So to use the following methods, you will be forced to manually import the following:
-
-.. code-block:: python
-
-    from geetools.DateRange import DateRangeAccessor
 
 Extra operations
 ################

--- a/geetools/Array/__init__.py
+++ b/geetools/Array/__init__.py
@@ -1,14 +1,4 @@
-"""Extra methods for the ``ee.Array`` class.
-
-.. warning::
-
-    As reported in https://github.com/gee-community/geetools/issues/173, this object cannot be extended before the API of
-    Earth Enfine is initialized. So to use the following methods, you will be forced to manually import the following:
-
-    .. code-block:: python
-
-        from geetools.Array import ArrayAccessor
-"""
+"""Extra methods for the ``ee.Array`` class."""
 from __future__ import annotations
 
 import ee

--- a/geetools/DateRange/__init__.py
+++ b/geetools/DateRange/__init__.py
@@ -1,15 +1,4 @@
-"""Extra tools for the ``ee.DateRange`` class.
-
-.. warning::
-
-    As reported in https://github.com/gee-community/geetools/issues/206, for user using ``earthengine-api<=0.1.388``
-    this object cannot be extended before the API of Earth Enfine is initialized. So to use the
-    following methods, you will be forced to manually import the following:
-
-    .. code-block:: python
-
-        from geetools.DateRange import DateRangeAccessor
-"""
+"""Extra tools for the ``ee.DateRange`` class."""
 from __future__ import annotations
 
 import ee

--- a/geetools/__init__.py
+++ b/geetools/__init__.py
@@ -42,11 +42,6 @@ from .String import StringAccessor
 from .ImageCollection import ImageCollectionAccessor
 from .Initialize import InitializeAccessor
 from .Authenticate import AuthenticateAccessor
-
-# Array cannot be imported directly in geetools prior to Initialisation
-# waiting for a fix in
-# https://github.com/gee-community/geetools/issues/173
-# https://github.com/gee-community/geetools/issues/206
 from .Array import ArrayAccessor
 from .DateRange import DateRangeAccessor
 

--- a/geetools/__init__.py
+++ b/geetools/__init__.py
@@ -47,8 +47,8 @@ from .Authenticate import AuthenticateAccessor
 # waiting for a fix in
 # https://github.com/gee-community/geetools/issues/173
 # https://github.com/gee-community/geetools/issues/206
-# from .Array import ArrayAccessor
-# from .DateRange import DateRangeAccessor
+from .Array import ArrayAccessor
+from .DateRange import DateRangeAccessor
 
 
 __title__ = "geetools"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "earthengine-api>=0.1.397", # support for ee.data.createFolder
+    "earthengine-api>=1", # fully static implementation
     "requests",
     "pandas",
     "geopandas",

--- a/tests/test_Array.py
+++ b/tests/test_Array.py
@@ -3,7 +3,6 @@ import ee
 import pytest
 
 import geetools
-from geetools.Array import ArrayAccessor  # noqa: F401
 
 
 class TestFull:

--- a/tests/test_DateRange.py
+++ b/tests/test_DateRange.py
@@ -3,7 +3,6 @@ import ee
 import pytest
 
 import geetools
-from geetools.DateRange import DateRangeAccessor  # noqa: F401
 
 
 class TestSplit:


### PR DESCRIPTION
FIx #206 
Fix #173 
Fix #290 

I finally can rely on the static definition of all GEE classes.