### PR TITLE
docs: fix edit in github link

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -96,7 +96,7 @@ html_theme_options = {
 html_context = {
     "github_user": "gee-community",
     "github_repo": "geetools",
-    "github_version": "master",
+    "github_version": "main",
     "doc_path": "docs",
 }
 html_css_files = ["custom.css"]


### PR DESCRIPTION
The edit in github button, available on all pages was still pointing to the old "master" branch making it impossible to reach the appropriate page from the documentation when a small edit was needed.