### PR TITLE
docs: add a single banner shared in all published documentation

### DIFF
--- a/docs/_static/banner.html
+++ b/docs/_static/banner.html
@@ -1,0 +1,7 @@
+<div class="sidebar-message">
+  This is a community-supported extension. If you'd like to contribute,
+  <a href="https://github.com/gee-community/geetools"
+    >check out our GitHub repository.</a
+  >
+  Your contributions are welcome!
+</div>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -82,6 +82,7 @@ html_theme_options = {
             "type": "fontawesome",
         },
     ],
+    "announcement": "https://raw.githubusercontent.com/gee-community/geetools/main/docs/_static/banner.html",
     "secondary_sidebar_items": [
         "page-toc.html",
         "edit-this-page.html",


### PR DESCRIPTION
fix #332 