### PR TITLE
reduce columns of `ee.FeatureCollection` by groups

### DIFF
--- a/tests/test_FeatureCollection/test_reduce_columns_group.yml
+++ b/tests/test_FeatureCollection/test_reduce_columns_group.yml
@@ -1,0 +1,16 @@
+Argentina:
+  Shape_Area:
+    mean: 11.59538319268763
+    sum: 278.2891966245031
+Armenia:
+  Shape_Area:
+    mean: 0.2852573993497455
+    sum: 3.1378313928472004
+Aruba:
+  Shape_Area:
+    mean: 0.0149496718126
+    sum: 0.0149496718126
+Arunachal Pradesh:
+  Shape_Area:
+    mean: 3.1213382042817
+    sum: 6.2426764085634

--- a/tests/test_FeatureCollection/test_reduce_columns_group_custom_output.yml
+++ b/tests/test_FeatureCollection/test_reduce_columns_group_custom_output.yml
@@ -1,0 +1,16 @@
+Argentina:
+  Shape_Area:
+    average_km2: 11.59538319268763
+    sum_km2: 278.2891966245031
+Armenia:
+  Shape_Area:
+    average_km2: 0.2852573993497455
+    sum_km2: 3.1378313928472004
+Aruba:
+  Shape_Area:
+    average_km2: 0.0149496718126
+    sum_km2: 0.0149496718126
+Arunachal Pradesh:
+  Shape_Area:
+    average_km2: 3.1213382042817
+    sum_km2: 6.2426764085634


### PR DESCRIPTION
This is a more complex version of https://github.com/gee-community/geetools/pull/373. This can be used when keys are not unique and we need to group using the values of a column, defined in `groupBy`.