### PR TITLE
docs: remove left side bar in API reference

### DIFF
--- a/docs/_templates/python/class.rst
+++ b/docs/_templates/python/class.rst
@@ -1,5 +1,7 @@
 {% if obj.display %}
    {% if is_own_page %}
+:html_theme.sidebar_secondary.remove:
+
 {{ obj.id.split(".")[-1] }}
 {{ "=" * obj.id.split(".")[-1] | length }}
 

--- a/docs/_templates/python/function.rst
+++ b/docs/_templates/python/function.rst
@@ -1,5 +1,7 @@
 {% if obj.display %}
    {% if is_own_page %}
+:html_theme.sidebar_secondary.remove:
+
 {{ obj.id.split(".")[-1] }}
 {{ "=" * obj.id.split(".")[-1] | length }}
 

--- a/docs/_templates/python/method.rst
+++ b/docs/_templates/python/method.rst
@@ -1,5 +1,7 @@
 {% if obj.display %}
    {% if is_own_page %}
+:html_theme.sidebar_secondary.remove:
+
 {{ obj.id.split(".")[-1] }}
 {{ "=" * obj.id.split(".")[-1] | length }}
 

--- a/docs/_templates/python/module.rst
+++ b/docs/_templates/python/module.rst
@@ -1,5 +1,7 @@
 {% if obj.display %}
    {% if is_own_page %}
+:html_theme.sidebar_secondary.remove:
+
 {{ obj.id.split(".")[-1] }}
 {{ "=" * obj.id.split(".")[-1] | length }}
 


### PR DESCRIPTION
As there is 1 single item per file this is basically useless. Also as the source is auto-generated by the docstring, the "edit on github" button is not pointing to an existing file. 