### PR TITLE
docs: Fix documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/autoapi/
 warnings.txt
 
 # PyBuilder

--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,9 @@ ipython_config.py
 #   install all needed dependencies.
 #Pipfile.lock
 
+# uv
+uv.lock
+
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/
 
@@ -140,6 +143,9 @@ cython_debug/
 
 # vscode config
 .vscode/
+
+# JetBrains config
+.idea/
 
 # sandbox Notebook
 sandbox.ipynb

--- a/docs/setup/pattern.rst
+++ b/docs/setup/pattern.rst
@@ -35,14 +35,14 @@ Here’s how we use these decorators to write a custom “geetools” accessor i
     @register_class_accessor(ee.Number, "geetools")
     class NumberAccessor:
 
-    def __init__(self, obj: ee.Number):
-        self._obj = obj
+        def __init__(self, obj: ee.Number):
+            self._obj = obj
 
-    def truncate(self, nbDecimals = 2):
-        """Truncate a number to a given number of decimals."""
-        nbDecimals = ee.Number(nbDecimals).toInt()
-        factor = ee.Number(10).pow(nbDecimals)
-        return self._obj.multiply(factor).toInt().divide(factor)
+        def truncate(self, nbDecimals = 2):
+            """Truncate a number to a given number of decimals."""
+            nbDecimals = ee.Number(nbDecimals).toInt()
+            factor = ee.Number(10).pow(nbDecimals)
+            return self._obj.multiply(factor).toInt().divide(factor)
 
 In general, the only restriction on the accessor class is that the ``__init__`` method must have a single parameter: the object it is supposed to work on.
 

--- a/geetools/accessors.py
+++ b/geetools/accessors.py
@@ -37,7 +37,7 @@ def register_class_accessor(klass: type, name: str) -> Callable:
     return decorator
 
 
-def register_function_accessor(func: type, name: str) -> Callable:
+def register_function_accessor(func: Callable, name: str) -> Callable:
     """Add an Accessor class to function through the provided namespace.
 
     Parameters:

--- a/geetools/accessors.py
+++ b/geetools/accessors.py
@@ -14,7 +14,7 @@ def register_class_accessor(klass: type, name: str) -> Callable:
         name: The name of the accessor namespace
 
     Returns:
-        The accessor function to to the class.
+        The accessor function to the class.
     """
 
     def decorator(accessor: Callable) -> object:
@@ -38,14 +38,14 @@ def register_class_accessor(klass: type, name: str) -> Callable:
 
 
 def register_function_accessor(func: type, name: str) -> Callable:
-    """Add a Accessor class to function through the provided namespace.
+    """Add an Accessor class to function through the provided namespace.
 
     Parameters:
         func: The function to set the accessor to.
         name: The name of the accessor namespace.
 
     Returns:
-        The accessor function to to the function.
+        The accessor function to the function.
     """
 
     def decorator(accessor: Callable) -> object:

--- a/geetools/ee_array.py
+++ b/geetools/ee_array.py
@@ -1,4 +1,4 @@
-"""Extra methods for the ``ee.Array`` class."""
+"""Extra methods for the :py:class:`ee.Array` class."""
 from __future__ import annotations
 
 import ee
@@ -8,7 +8,7 @@ from .accessors import register_class_accessor
 
 @register_class_accessor(ee.Array, "geetools")
 class ArrayAccessor:
-    """Toolbox for the ``ee.Array`` class."""
+    """Toolbox for the :py:class:`ee.Array` class."""
 
     def __init__(self, obj: ee.Array):
         """Initialize the Array class."""

--- a/geetools/ee_asset.py
+++ b/geetools/ee_asset.py
@@ -110,7 +110,7 @@ class Asset(os.PathLike):
         return self._path.as_posix()
 
     def as_uri(self) -> str:
-        """Return the asset id as a uri.
+        """Return the asset id as an uri.
 
         The uri can be directly copy/pasted to your browser to see the asset in the GEE code editor.
 
@@ -126,7 +126,7 @@ class Asset(os.PathLike):
         """Return True if the asset is absolute.
 
         An absolute asset path starts with "projects" and contains "assets" at the 3rd position.
-        We don't check if the project name exist in this method, simply the sctructure of the path.
+        We don't check if the project name exist in this method, simply the structure of the path.
 
         Args:
             raised: If True, raise an exception if the asset is not absolute. Defaults to False.
@@ -495,7 +495,7 @@ class Asset(os.PathLike):
         Args:
             parents: If True, create all the parents of the folder. Defaults to False.
             exist_ok: If True, do not raise an error if the folder already exists. Defaults to False.
-            image_collection: If True, create an image collection asset. Otherwise create a folder asset. Defaults to False.
+            image_collection: If True, create an image collection asset. Otherwise, create a folder asset. Defaults to False.
 
         Examples:
             .. code-block:: python
@@ -579,7 +579,7 @@ class Asset(os.PathLike):
     def delete(self, recursive: bool = False, dry_run: bool | None = None) -> list:
         """Remove the asset.
 
-        This method will delete an asset (any type) asset and all its potential children. by default it is not recursive and will raise an error if the container is not empty.
+        This method will delete an asset (any type) asset and all its potential children. By default, it is not recursive and will raise an error if the container is not empty.
         By setting the recursive argument to True, the method will delete all the children and the container asset (including potential subfolders).
         To avoid deleting important assets by accident the method is set to dry_run by default.
 

--- a/geetools/ee_authenticate.py
+++ b/geetools/ee_authenticate.py
@@ -1,4 +1,4 @@
-"""Toolbox for the ``ee.Authenticate`` function."""
+"""Toolbox for the :py:func:`ee.Authenticate` function."""
 from __future__ import annotations
 
 from contextlib import suppress
@@ -13,13 +13,13 @@ from .accessors import register_function_accessor
 
 @register_function_accessor(ee.Authenticate, "geetools")
 class AuthenticateAccessor:
-    """Create an accessor for the ``ee.Authenticate`` function."""
+    """Create an accessor for the :py:func:`ee.Authenticate` function."""
 
     @staticmethod
     def new_user(name: str = "", credential_pathname: str = "") -> None:
         """Authenticate the user and save the credentials in a specific folder.
 
-        Equivalent to ee.Authenticate but where the registered user will not be the default one (the one you get when running :py:meth:`ee.Initialize`)
+        Equivalent to :py:func:`ee.Authenticate` but where the registered user will not be the default one (the one you get when running :py:func:`ee.Initialize`)
 
         Args:
             name: The name of the user. If not set, it will reauthenticate default.
@@ -80,7 +80,7 @@ class AuthenticateAccessor:
             (credential_path / name).unlink()
 
     @staticmethod
-    def list_user(credential_pathname: str = "") -> list:
+    def list_user(credential_pathname: str = "") -> list[str]:
         """return all the available users in the set folder.
 
         To reach "default" simply omit the ``name`` parameter in the User methods

--- a/geetools/ee_computed_object.py
+++ b/geetools/ee_computed_object.py
@@ -45,9 +45,9 @@ def isInstance(self, klass: type) -> ee.Number:
 # -- .gee files ----------------------------------------------------------------
 @_register_extention(ee.ComputedObject)  # type: ignore
 def save(self, path: os.PathLike) -> Path:
-    """Save a ``ComputedObject`` to a .gee file.
+    """Save a :py:class:`ee.ComputedObject` to a .gee file.
 
-    The file contains the JSON representation of the object. It still needs to be computed via ``getInfo()`` to be used.
+    The file contains the JSON representation of the object. It still needs to be computed via :py:meth:`ee.ComputedObject.getInfo` to be used.
 
     Parameters:
         path: The path to save the object to.

--- a/geetools/ee_computed_object.py
+++ b/geetools/ee_computed_object.py
@@ -1,4 +1,4 @@
-"""Extra tools for the ``ee.ComputedObject`` class."""
+"""Extra tools for the :py:class:`ee.ComputedObject` class."""
 from __future__ import annotations
 
 import json

--- a/geetools/ee_computed_object.py
+++ b/geetools/ee_computed_object.py
@@ -47,7 +47,7 @@ def isInstance(self, klass: type) -> ee.Number:
 def save(self, path: os.PathLike) -> Path:
     """Save a ``ComputedObject`` to a .gee file.
 
-    The file contains the JSON representation of the object. it still need to be computed via ``getInfo()`` to be used.
+    The file contains the JSON representation of the object. It still needs to be computed via ``getInfo()`` to be used.
 
     Parameters:
         path: The path to save the object to.

--- a/geetools/ee_date.py
+++ b/geetools/ee_date.py
@@ -1,4 +1,4 @@
-"""Extra methods for the ``ee.Date`` class."""
+"""Extra methods for the :py:class:`ee.Date` class."""
 from __future__ import annotations
 
 from datetime import datetime
@@ -12,7 +12,7 @@ EE_EPOCH = datetime(1970, 1, 1, 0, 0, 0)
 
 @register_class_accessor(ee.Date, "geetools")
 class DateAccessor:
-    """Toolbox for the ``ee.Date`` class."""
+    """Toolbox for the :py:class:`ee.Date` class."""
 
     def __init__(self, obj: ee.Date):
         """Initialize the Date class."""
@@ -27,7 +27,7 @@ class DateAccessor:
             unit: The unit to return the number of. One of: ``second``, ``minute``, ``hour``, ``day``, ``month``, ``year``.
 
         Returns:
-            The date as a ``ee.Date`` object.
+            The date as a :py:class:`ee.Date` object.
 
         Examples:
             .. jupyter-execute::
@@ -52,7 +52,7 @@ class DateAccessor:
             year: The year.
 
         Returns:
-            The date as a ``ee.Date`` object.
+            The date as a :py:class:`ee.Date` object.
 
         Examples:
             .. jupyter-execute::
@@ -89,10 +89,10 @@ class DateAccessor:
         return ee.Date(datetime.now().isoformat())
 
     def to_datetime(self) -> datetime:
-        """Convert a ``ee.Date`` to a ``datetime.datetime``.
+        """Convert a :py:class:`ee.Date` to a :py:class:`datetime.datetime`.
 
         Returns:
-            The ``datetime.datetime`` representation of the ``ee.Date``.
+            The :py:class:`datetime.datetime` representation of the :py:class:`ee.Date`.
 
         Examples:
             .. jupyter-execute::

--- a/geetools/ee_date_range.py
+++ b/geetools/ee_date_range.py
@@ -1,4 +1,4 @@
-"""Extra tools for the ``ee.DateRange`` class."""
+"""Extra tools for the :py:class:`ee.DateRange` class."""
 from __future__ import annotations
 
 import ee
@@ -8,7 +8,7 @@ from .accessors import register_class_accessor
 
 @register_class_accessor(ee.DateRange, "geetools")
 class DateRangeAccessor:
-    """Toolbox for the ``ee.DateRange`` class."""
+    """Toolbox for the :py:class:`ee.DateRange` class."""
 
     def __init__(self, obj: ee.DateRange):
         """Initialize the DateRange class."""
@@ -16,7 +16,7 @@ class DateRangeAccessor:
 
     # -- date range operations -------------------------------------------------
     def split(self, interval: int | ee.Number, unit: str = "day") -> ee.List:
-        """Convert a ``ee.DateRange`` to a list of ``ee.DateRange``.
+        """Convert a :py:class:`ee.DateRange` to a list of :py:class:`ee.DateRange`.
 
         The DateRange will be split in multiple DateRanges of the specified interval and Unit.
         For example "1", "day". if the end date is not included the last dateRange length will be adapted.

--- a/geetools/ee_dictionary.py
+++ b/geetools/ee_dictionary.py
@@ -16,10 +16,10 @@ class DictionaryAccessor:
 
     # -- alternative constructor -----------------------------------------------
     def fromPairs(self, list_: list | ee.List) -> ee.Dictionary:
-        """Create a dictionary from a list of [[key, value], ...]] pairs.
+        """Create a dictionary from a list of ``[[key, value], ...]]`` pairs.
 
         Parameters:
-            list_: A list of pairs (key, value).
+            list_: A list of pairs ``(key, value)``.
 
         Returns:
             A dictionary using the pairs.

--- a/geetools/ee_dictionary.py
+++ b/geetools/ee_dictionary.py
@@ -15,11 +15,11 @@ class DictionaryAccessor:
         self._obj = obj
 
     # -- alternative constructor -----------------------------------------------
-    def fromPairs(self, list_: list | ee.List) -> ee.Dictionary:
+    def fromPairs(self, list: list | ee.List) -> ee.Dictionary:
         """Create a dictionary from a list of ``[[key, value], ...]]`` pairs.
 
         Parameters:
-            list_: A list of pairs ``(key, value)``.
+            list: A list of pairs ``(key, value)``.
 
         Returns:
             A dictionary using the pairs.
@@ -35,9 +35,9 @@ class DictionaryAccessor:
                 d = ee.Dictionary.geetools.fromPairs([["foo", 1], ["bar", 2]])
                 d.getInfo()
         """
-        list_ = ee.List(list_)
-        keys = list_.map(lambda pair: ee.List(pair).get(0))
-        values = list_.map(lambda pair: ee.List(pair).get(1))
+        list = ee.List(list)
+        keys = list.map(lambda pair: ee.List(pair).get(0))
+        values = list.map(lambda pair: ee.List(pair).get(1))
         return ee.Dictionary.fromLists(keys, values)
 
     # -- dictionary operations -------------------------------------------------
@@ -62,11 +62,11 @@ class DictionaryAccessor:
         values = orderededKeys.map(lambda key: self._obj.get(key))
         return ee.Dictionary.fromLists(orderededKeys, values)
 
-    def getMany(self, list_: list | ee.List) -> ee.List:
+    def getMany(self, list: list | ee.List) -> ee.List:
         """Extract values from a list of keys.
 
         Parameters:
-            list_: A list of keys.
+            list: A list of keys.
 
         Returns:
             A list of values.
@@ -83,4 +83,4 @@ class DictionaryAccessor:
                 d = d.geetools.getMany(["foo", "bar"])
                 d.getInfo()
         """
-        return ee.List(list_).map(lambda key: self._obj.get(key))
+        return ee.List(list).map(lambda key: self._obj.get(key))

--- a/geetools/ee_dictionary.py
+++ b/geetools/ee_dictionary.py
@@ -1,4 +1,4 @@
-"""Extra methods for the ``ee.Dictionary`` class."""
+"""Extra methods for the :py:class:`ee.Dictionary` class."""
 from __future__ import annotations
 
 import ee
@@ -8,18 +8,18 @@ from .accessors import register_class_accessor
 
 @register_class_accessor(ee.Dictionary, "geetools")
 class DictionaryAccessor:
-    """Toolbox for the ``ee.Dictionary`` class."""
+    """Toolbox for the :py:class:`ee.Dictionary` class."""
 
     def __init__(self, obj: ee.Dictionary):
         """Initialize the Dictionary class."""
         self._obj = obj
 
     # -- alternative constructor -----------------------------------------------
-    def fromPairs(self, list: list | ee.List) -> ee.Dictionary:
+    def fromPairs(self, list_: list | ee.List) -> ee.Dictionary:
         """Create a dictionary from a list of [[key, value], ...]] pairs.
 
         Parameters:
-            list: A list of pairs (key, value).
+            list_: A list of pairs (key, value).
 
         Returns:
             A dictionary using the pairs.
@@ -35,9 +35,9 @@ class DictionaryAccessor:
                 d = ee.Dictionary.geetools.fromPairs([["foo", 1], ["bar", 2]])
                 d.getInfo()
         """
-        list = ee.List(list)
-        keys = list.map(lambda pair: ee.List(pair).get(0))
-        values = list.map(lambda pair: ee.List(pair).get(1))
+        list_ = ee.List(list_)
+        keys = list_.map(lambda pair: ee.List(pair).get(0))
+        values = list_.map(lambda pair: ee.List(pair).get(1))
         return ee.Dictionary.fromLists(keys, values)
 
     # -- dictionary operations -------------------------------------------------
@@ -62,11 +62,11 @@ class DictionaryAccessor:
         values = orderededKeys.map(lambda key: self._obj.get(key))
         return ee.Dictionary.fromLists(orderededKeys, values)
 
-    def getMany(self, list: list | ee.List) -> ee.List:
+    def getMany(self, list_: list | ee.List) -> ee.List:
         """Extract values from a list of keys.
 
         Parameters:
-            list: A list of keys.
+            list_: A list of keys.
 
         Returns:
             A list of values.
@@ -83,4 +83,4 @@ class DictionaryAccessor:
                 d = d.geetools.getMany(["foo", "bar"])
                 d.getInfo()
         """
-        return ee.List(list).map(lambda key: self._obj.get(key))
+        return ee.List(list_).map(lambda key: self._obj.get(key))

--- a/geetools/ee_export.py
+++ b/geetools/ee_export.py
@@ -9,7 +9,7 @@ from .utils import format_asset_id, format_description
 
 @register_class_accessor(ee.batch.Export, "geetools")
 class ExportAccessor:
-    """Toolbox for the ``ee.batch.Export`` class."""
+    """Toolbox for the :py:class:`ee.batch.Export` class."""
 
     def __init__(self, obj: ee.batch.Export):
         """Initialize the ExportAccessor class."""

--- a/geetools/ee_export.py
+++ b/geetools/ee_export.py
@@ -62,7 +62,6 @@ class ExportAccessor:
 
                     # export the collection
                     tasks = geetools.batch.Export.imagecollection.toAsset(collection, "system:index", "test export")
-                ```
             """
             # sanity check on parameters
             # renaming them for mypy type reassignment and compactness

--- a/geetools/ee_export.py
+++ b/geetools/ee_export.py
@@ -41,10 +41,10 @@ class ExportAccessor:
 
             Parameters:
                 imagecollection: The image collection to export.
-                index_property: The property of the image to use as name. Default is "system:id".
+                index_property: The property of the image to use as name. Default is ``"system:id"``.
                 description: The description of the task.
                 assetId: The asset id where to export the image collection.
-                **kwargs: every parameter that you would use for a vanilla ee.batch.Export.image.toAsset
+                **kwargs: every parameter that you would use for a vanilla :py:meth:`ee.batch.Export.image.toAsset`
 
             Returns:
                 The task created.
@@ -107,10 +107,10 @@ class ExportAccessor:
 
             Parameters:
                 imagecollection: The image collection to export.
-                index_property: The property of the image to use as name. Default is "system:id".
+                index_property: The property of the image to use as name. Default is ``"system:id"``.
                 description: The description of the task.
                 folder: The folder id where to export the image collection. It will be stored at the root of the drive.
-                **kwargs: every parameter that you would use for a vanilla ee.batch.Export.image.toDrive
+                **kwargs: every parameter that you would use for a vanilla :py:meth:`ee.batch.Export.image.toDrive`
 
             Returns:
                 The list of created tasks
@@ -171,10 +171,10 @@ class ExportAccessor:
 
             Parameters:
                 imagecollection: The image collection to export.
-                index_property: The property of the image to use as name. Default is "system:id".
+                index_property: The property of the image to use as name. Default is ``"system:id"``.
                 description: The description of the task.
                 folder: The folder id where to export the image collection. It will be stored at the root of the drive.
-                **kwargs: every parameter that you would use for a vanilla ee.batch.Export.image.toCloudStorage
+                **kwargs: every parameter that you would use for a vanilla :py:meth:`ee.batch.Export.image.toCloudStorage`
 
             Returns:
                 The list of created tasks

--- a/geetools/ee_feature.py
+++ b/geetools/ee_feature.py
@@ -1,4 +1,4 @@
-"""Toolbox for the ``ee.Feature`` class."""
+"""Toolbox for the :py:class:`ee.Feature` class."""
 from __future__ import annotations
 
 import ee
@@ -8,7 +8,7 @@ from .accessors import register_class_accessor
 
 @register_class_accessor(ee.Feature, "geetools")
 class FeatureAccessor:
-    """Toolbox for the ``ee.Feature`` class."""
+    """Toolbox for the :py:class:`ee.Feature` class."""
 
     def __init__(self, obj: ee.Feature):
         """Initialize the class."""

--- a/geetools/ee_feature.py
+++ b/geetools/ee_feature.py
@@ -18,7 +18,7 @@ class FeatureAccessor:
         """Convert a :py:class:`ee.Feature` composed of a multiGeometry geometry into a :py:class:`ee.FeatureCollection`.
 
         Returns:
-            The FeatureCollection
+            The :py:class:`ee.FeatureCollection`
 
         Example:
             .. jupyter-execute::

--- a/geetools/ee_feature_collection.py
+++ b/geetools/ee_feature_collection.py
@@ -185,6 +185,7 @@ class FeatureCollectionAccessor:
         idByIndex = ee.Dictionary.fromLists(indexes, ids)
         return self._obj.map(lambda f: f.set(name, idByIndex.get(f.get("system:index"))))
 
+    # TODO: Fix the example
     def mergeGeometries(self, maxError: float | int | ee.number | None = None) -> ee.Geometry:
         """Merge the geometries included in the features.
 
@@ -195,7 +196,7 @@ class FeatureCollectionAccessor:
             the dissolved geometry
 
         Example:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
                 from geetools.utils import initialize_documentation

--- a/geetools/ee_feature_collection.py
+++ b/geetools/ee_feature_collection.py
@@ -275,7 +275,7 @@ class FeatureCollectionAccessor:
         properties: list | ee.List = [],
         labels: list = [],
     ) -> ee.Dictionary:
-        """Get a dictionary with all feature values for each properties.
+        """Get a dictionary with all feature values for each property.
 
         This method is returning a dictionary with all the properties as keys and their values in each feature as a list.
 
@@ -295,7 +295,7 @@ class FeatureCollectionAccessor:
             labels: A list of names to replace properties names. Default to the properties names.
 
         Returns:
-            A dictionary with all the properties as keys and their values in each feaure as a list.
+            A dictionary with all the properties as keys and their values in each feature as a list.
 
         See Also:
             - :docstring:`ee.FeatureCollection.geetools.byFeatures`

--- a/geetools/ee_feature_collection.py
+++ b/geetools/ee_feature_collection.py
@@ -700,7 +700,7 @@ class FeatureCollectionAccessor:
             The created FeatureCollection.
 
         Examples:
-            code-block:: python
+            .. code-block:: python
 
                 import geetools
 

--- a/geetools/ee_feature_collection.py
+++ b/geetools/ee_feature_collection.py
@@ -64,7 +64,7 @@ class FeatureCollectionAccessor:
                 # transform the featureCollection into an image
                 img = vatican.geetools.toImage(color=1).rename("gaul")
 
-                # Define a custom colormap ffor the raster representation
+                # Define a custom colormap for the raster representation
                 # it will only have 1 color: teal for the first value and white for everything else
                 cmap = ListedColormap(['teal', 'white'])
 
@@ -186,11 +186,11 @@ class FeatureCollectionAccessor:
         return self._obj.map(lambda f: f.set(name, idByIndex.get(f.get("system:index"))))
 
     # TODO: Fix the example
-    def mergeGeometries(self, maxError: float | int | ee.number | None = None) -> ee.Geometry:
+    def mergeGeometries(self, maxError: float | int | ee.Number | None = None) -> ee.Geometry:
         """Merge the geometries included in the features.
 
         Args:
-            maxError: The maximum amount of error tolerated when performing any necessary reprojection.
+            maxError: The maximum amount of error tolerated when performing any necessary re-projection.
 
         Returns:
             the dissolved geometry
@@ -204,7 +204,7 @@ class FeatureCollectionAccessor:
 
                 initialize_documentation()
 
-                # create a featurecollection containing 2 bounding boxes
+                # create a FeatureCollection containing 2 bounding boxes
                 fc = ee.FeatureCollection([
                     ee.Geometry.BBox(-1, -1, 1, 1),
                     ee.Geometry.BBox(0, 0, 2, 2)
@@ -229,7 +229,7 @@ class FeatureCollectionAccessor:
 
         This method is made to avoid errors when performing zonal statistics and/or other surfaces operations.
         These operations won't work on geometries that are Lines or points. The methods remove these geometry
-        types from GEometryCollections and rremove features that don't have any polygon geometry.
+        types from GeometryCollections and remove features that don't have any polygon geometry.
 
         Returns:
             The parsed collection with only polygon/MultiPolygon geometries
@@ -277,7 +277,7 @@ class FeatureCollectionAccessor:
     ) -> ee.Dictionary:
         """Get a dictionary with all feature values for each properties.
 
-        This method is returning a dictionary with all the properties as keys and their values in each feaure as a list.
+        This method is returning a dictionary with all the properties as keys and their values in each feature as a list.
 
         .. code-block::
 
@@ -422,9 +422,9 @@ class FeatureCollectionAccessor:
             type: The type of plot to use. Defaults to "bar". can be any type of plot from the python lib `matplotlib.pyplot`. If the one you need is missing open an issue!
             featureId: The property to use as the x-axis (name the features). Defaults to "system:index".
             properties: A list of properties to plot. Defaults to all properties.
-            labels: A list of labels to use for plotting the properties. If not provided, the default labels will be used. It needs to match the properties length.
+            labels: A list of labels to use for plotting the properties. If not provided, the default labels will be used. It needs to match the properties' length.
             colors: A list of colors to use for plotting the properties. If not provided, the default colors from the matplotlib library will be used.
-            ax: The matplotlib axes to use. If not provided, the plot will be send to a new figure.
+            ax: The matplotlib axes to use. If not provided, the plot will be sent to a new figure.
             kwargs: Additional arguments from the ``pyplot`` function.
 
         See Also:
@@ -488,9 +488,9 @@ class FeatureCollectionAccessor:
             type: The type of plot to use. Defaults to "bar". can be any type of plot from the python lib `matplotlib.pyplot`. If the one you need is missing open an issue!
             featureId: The property to use as the y-axis (name the features). Defaults to "system:index".
             properties: A list of properties to plot. Defaults to all properties.
-            labels: A list of labels to use for plotting the properties. If not provided, the default labels will be used. It needs to match the properties length.
+            labels: A list of labels to use for plotting the properties. If not provided, the default labels will be used. It needs to match the properties' length.
             colors: A list of colors to use for plotting the properties. If not provided, the default colors from the matplotlib library will be used.
-            ax: The matplotlib axes to use. If not provided, the plot will be send to a new figure.
+            ax: The matplotlib axes to use. If not provided, the plot will be sent to a new figure.
             kwargs: Additional arguments from the ``pyplot`` function.
 
         See Also:
@@ -546,7 +546,7 @@ class FeatureCollectionAccessor:
         Args:
             property: The property to display
             label: The label to use for the property. If not provided, the property name will be used.
-            ax: The matplotlib axes to use. If not provided, the plot will be send to the current axes (``plt.gca()``)
+            ax: The matplotlib axes to use. If not provided, the plot will be sent to the current axes (``plt.gca()``)
             color: The color to use for the plot. If not provided, the default colors from the matplotlib library will be used.
             kwargs: Additional arguments from the ``pyplot.hist`` function.
 
@@ -657,7 +657,7 @@ class FeatureCollectionAccessor:
                 )
 
                 # style the figure
-                ax.set_title("France departements")
+                ax.set_title("France departments")
                 ax.set_xlabel("Longitude (°)")
                 ax.set_ylabel("Latitude (°)")
                 ax.set_xticks([])

--- a/geetools/ee_feature_collection.py
+++ b/geetools/ee_feature_collection.py
@@ -36,14 +36,14 @@ class FeatureCollectionAccessor:
     ) -> ee.Image:
         """Paint the current :py:class:`ee.FeatureCollection` to an Image.
 
-        It's a simple wrapper on Image.paint() method
+        It's a simple wrapper on :py:meth:`ee.Image.paint` method.
 
         Args:
             color: The pixel value to paint into every band of the input image, either as a number which will be used for all features, or the name of a numeric property to take from each feature in the collection.
             width: Line width, either as a number which will be the line width for all geometries, or the name of a numeric property to take from each feature in the collection. If unspecified, the geometries will be filled instead of outlined.
 
         Returns:
-            The painted image
+            The painted image.
 
         Examples:
             .. jupyter-execute::
@@ -139,11 +139,11 @@ class FeatureCollectionAccessor:
         """Add a unique numeric identifier, starting from parameter ``start``.
 
         Args:
-            name: The name of the property to add. Defaults to "id".
+            name: The name of the property to add. Defaults to ``"id"``.
             start: The starting value of the id. Defaults to 1.
 
         Returns:
-            The parsed collection with a new id property
+            The parsed collection with a new id property.
 
         Example:
             .. jupyter-execute::
@@ -193,7 +193,7 @@ class FeatureCollectionAccessor:
             maxError: The maximum amount of error tolerated when performing any necessary re-projection.
 
         Returns:
-            the dissolved geometry
+            The dissolved geometry.
 
         Example:
             .. code-block:: python
@@ -232,7 +232,7 @@ class FeatureCollectionAccessor:
         types from GeometryCollections and remove features that don't have any polygon geometry.
 
         Returns:
-            The parsed collection with only polygon/MultiPolygon geometries
+            The parsed collection with only polygon/MultiPolygon geometries.
 
         Example:
             .. code-block:: python
@@ -425,7 +425,7 @@ class FeatureCollectionAccessor:
             labels: A list of labels to use for plotting the properties. If not provided, the default labels will be used. It needs to match the properties' length.
             colors: A list of colors to use for plotting the properties. If not provided, the default colors from the matplotlib library will be used.
             ax: The matplotlib axes to use. If not provided, the plot will be sent to a new figure.
-            kwargs: Additional arguments from the ``pyplot`` function.
+            kwargs: Additional arguments from the ``pyplot`` type selected.
 
         See Also:
             - :docstring:`ee.FeatureCollection.geetools.byFeatures`
@@ -546,9 +546,9 @@ class FeatureCollectionAccessor:
         Args:
             property: The property to display
             label: The label to use for the property. If not provided, the property name will be used.
-            ax: The matplotlib axes to use. If not provided, the plot will be sent to the current axes (``plt.gca()``)
+            ax: The matplotlib axes to use. If not provided, the plot will be sent to the current axes (using :py:func:`matplotlib.pyplot.gca`).
             color: The color to use for the plot. If not provided, the default colors from the matplotlib library will be used.
-            kwargs: Additional arguments from the :py:func:`matplotlib.pyplot.hist` function.
+            **kwargs: Additional arguments from the :py:func:`matplotlib.pyplot.hist` function.
 
         See Also:
             - :docstring:`ee.FeatureCollection.geetools.plot_by_features`
@@ -696,10 +696,10 @@ class FeatureCollectionAccessor:
 
         Parameters:
             data: The geo_interface to create the :py:class:`ee.FeatureCollection` from.
-            crs: The CRS to use for the FeatureCollection. Default to "EPSG:4326".
+            crs: The CRS to use for the FeatureCollection. Default to ``EPSG:4326``.
 
         Returns:
-            The created FeatureCollection.
+            The created :py:class:`ee.FeatureCollection` from the geo_interface.
 
         Examples:
             .. code-block:: python

--- a/geetools/ee_feature_collection.py
+++ b/geetools/ee_feature_collection.py
@@ -1,4 +1,4 @@
-"""Toolbox for the `ee.FeatureCollection` class."""
+"""Toolbox for the :py:class:`ee.FeatureCollection` class."""
 from __future__ import annotations
 
 from typing import Protocol
@@ -23,10 +23,10 @@ class GeoInterface(Protocol):
 
 @register_class_accessor(ee.FeatureCollection, "geetools")
 class FeatureCollectionAccessor:
-    """Toolbox for the `ee.FeatureCollection` class."""
+    """Toolbox for the :py:class:`ee.FeatureCollection` class."""
 
     def __init__(self, obj: ee.FeatureCollection):
-        """Initialize the FeatureCollection class."""
+        """Initialize the :py:class:`ee.FeatureCollection` class."""
         self._obj = obj
 
     def toImage(
@@ -34,7 +34,7 @@ class FeatureCollectionAccessor:
         color: str | ee.String | int | ee.Number = 0,
         width: str | ee.String | int | ee.Number = "",
     ) -> ee.Image:
-        """Paint the current FeatureCollection to an Image.
+        """Paint the current :py:class:`ee.FeatureCollection` to an Image.
 
         It's a simple wrapper on Image.paint() method
 
@@ -102,7 +102,7 @@ class FeatureCollectionAccessor:
             selectors: a list of properties to add in the output. If the list is empty all properties will be added.
 
         Returns:
-            a ee.Dictionary with values of keyColumn as keys and ee.Dictionary as values. The output will look like:
+            a :py:class:`ee.Dictionary` with values of keyColumn as keys and :py:class:`ee.Dictionary` as values. The output will look like:
 
         Examples:
             .. jupyter-execute::
@@ -290,7 +290,7 @@ class FeatureCollectionAccessor:
         The output remain server side and can be used to create a client side plot.
 
         Args:
-            featureId: The property used to label features. Defaults to "system:index".
+            featureId: The property used to label features. Defaults to ``"system:index"``.
             properties: A list of properties to get the values from.
             labels: A list of names to replace properties names. Default to the properties names.
 
@@ -353,7 +353,7 @@ class FeatureCollectionAccessor:
         The output remain server side and can be used to create a client side plot.
 
         Args:
-            featureId: The property to use as the feature id. Defaults to "system:index". This property needs to be a string property.
+            featureId: The property to use as the feature id. Defaults to ``"system:index"``. This property needs to be a string property.
             properties: A list of properties to get the values from.
             labels: A list of names to replace properties names. Default to the properties names.
 
@@ -409,18 +409,18 @@ class FeatureCollectionAccessor:
         ax: Axes | None = None,
         **kwargs,
     ) -> Axes:
-        """Plot the values of a ``ee.FeatureCollection`` by feature.
+        """Plot the values of a :py:class:`ee.FeatureCollection` by feature.
 
         Each feature property selected in properties will be plotted using the ``featureId`` as the x-axis.
         If no ``properties`` are provided, all properties will be plotted.
-        If no ``featureId`` is provided, the "system:index" property will be used.
+        If no ``featureId`` is provided, the ``"system:index"`` property will be used.
 
         Warning:
             This function is a client-side function.
 
         Args:
-            type: The type of plot to use. Defaults to "bar". can be any type of plot from the python lib `matplotlib.pyplot`. If the one you need is missing open an issue!
-            featureId: The property to use as the x-axis (name the features). Defaults to "system:index".
+            type: The type of plot to use. Defaults to ``"bar"``. can be any type of plot from the python lib ``matplotlib.pyplot``. If the one you need is missing open an issue!
+            featureId: The property to use as the x-axis (name the features). Defaults to ``"system:index"``.
             properties: A list of properties to plot. Defaults to all properties.
             labels: A list of labels to use for plotting the properties. If not provided, the default labels will be used. It needs to match the properties' length.
             colors: A list of colors to use for plotting the properties. If not provided, the default colors from the matplotlib library will be used.
@@ -477,7 +477,7 @@ class FeatureCollectionAccessor:
         ax: Axes | None = None,
         **kwargs,
     ) -> Axes:
-        """Plot the values of a FeatureCollection by property.
+        """Plot the values of a :py:class:`ee.FeatureCollection` by property.
 
         Each features will be represented by a color and each property will be a bar of the bar chart.
 
@@ -485,8 +485,8 @@ class FeatureCollectionAccessor:
             This function is a client-side function.
 
         Args:
-            type: The type of plot to use. Defaults to "bar". can be any type of plot from the python lib `matplotlib.pyplot`. If the one you need is missing open an issue!
-            featureId: The property to use as the y-axis (name the features). Defaults to "system:index".
+            type: The type of plot to use. Defaults to ``"bar"``. can be any type of plot from the python lib ``matplotlib.pyplot``. If the one you need is missing open an issue!
+            featureId: The property to use as the y-axis (name the features). Defaults to ``"system:index"``.
             properties: A list of properties to plot. Defaults to all properties.
             labels: A list of labels to use for plotting the properties. If not provided, the default labels will be used. It needs to match the properties' length.
             colors: A list of colors to use for plotting the properties. If not provided, the default colors from the matplotlib library will be used.
@@ -548,7 +548,7 @@ class FeatureCollectionAccessor:
             label: The label to use for the property. If not provided, the property name will be used.
             ax: The matplotlib axes to use. If not provided, the plot will be sent to the current axes (``plt.gca()``)
             color: The color to use for the plot. If not provided, the default colors from the matplotlib library will be used.
-            kwargs: Additional arguments from the ``pyplot.hist`` function.
+            kwargs: Additional arguments from the :py:func:`matplotlib.pyplot.hist` function.
 
         See Also:
             - :docstring:`ee.FeatureCollection.geetools.plot_by_features`
@@ -685,7 +685,7 @@ class FeatureCollectionAccessor:
 
     @classmethod
     def fromGeoInterface(cls, data: dict | GeoInterface) -> ee.FeatureCollection:
-        """Create a FeatureCollection from a geo interface.
+        """Create a :py:class:`ee.FeatureCollection` from a geo interface.
 
         The ``geo_interface`` is a protocol representing a vector collection as a python GeoJSON-like dictionary structure.
         More information is available at https://gist.github.com/sgillies/2217756. Note that the :py:class:`ee.FeatureCollection`
@@ -695,7 +695,7 @@ class FeatureCollectionAccessor:
         that respects the protocol described in the link above.
 
         Parameters:
-            data: The geo_interface to create the FeatureCollection from.
+            data: The geo_interface to create the :py:class:`ee.FeatureCollection` from.
             crs: The CRS to use for the FeatureCollection. Default to "EPSG:4326".
 
         Returns:

--- a/geetools/ee_feature_collection.py
+++ b/geetools/ee_feature_collection.py
@@ -223,6 +223,7 @@ class FeatureCollectionAccessor:
         union = self._obj.iterate(lambda f, g: f.geometry().union(g, maxError=maxError), first)
         return ee.Geometry(union).dissolve(maxError=maxError)
 
+    # TODO: Fix the example
     def toPolygons(self) -> ee.FeatureCollection:
         """Drop any geometry that is not a Polygon or a multipolygon.
 
@@ -234,7 +235,7 @@ class FeatureCollectionAccessor:
             The parsed collection with only polygon/MultiPolygon geometries
 
         Example:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
                 from geetools.utils import initialize_documentation

--- a/geetools/ee_feature_collection.py
+++ b/geetools/ee_feature_collection.py
@@ -195,7 +195,7 @@ class FeatureCollectionAccessor:
             the dissolved geometry
 
         Example:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
                 from geetools.utils import initialize_documentation
@@ -233,7 +233,7 @@ class FeatureCollectionAccessor:
             The parsed collection with only polygon/MultiPolygon geometries
 
         Example:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
                 from geetools.utils import initialize_documentation

--- a/geetools/ee_feature_collection.py
+++ b/geetools/ee_feature_collection.py
@@ -185,7 +185,6 @@ class FeatureCollectionAccessor:
         idByIndex = ee.Dictionary.fromLists(indexes, ids)
         return self._obj.map(lambda f: f.set(name, idByIndex.get(f.get("system:index"))))
 
-    # TODO: Fix the example
     def mergeGeometries(self, maxError: float | int | ee.Number | None = None) -> ee.Geometry:
         """Merge the geometries included in the features.
 
@@ -223,7 +222,6 @@ class FeatureCollectionAccessor:
         union = self._obj.iterate(lambda f, g: f.geometry().union(g, maxError=maxError), first)
         return ee.Geometry(union).dissolve(maxError=maxError)
 
-    # TODO: Fix the example
     def toPolygons(self) -> ee.FeatureCollection:
         """Drop any geometry that is not a Polygon or a multipolygon.
 

--- a/geetools/ee_filter.py
+++ b/geetools/ee_filter.py
@@ -1,4 +1,4 @@
-"""Extra method for the ``ee.Filter`` class."""
+"""Extra method for the :py:class:`ee.Filter` class."""
 from __future__ import annotations
 
 import ee
@@ -8,7 +8,7 @@ from .accessors import register_class_accessor
 
 @register_class_accessor(ee.Filter, "geetools")
 class FilterAccessor:
-    """Toolbox for the ``ee.Filter`` class."""
+    """Toolbox for the :py:class:`ee.Filter` class."""
 
     def __init__(self, obj: ee.Filter):
         """Initialize the Filter class."""

--- a/geetools/ee_geometry.py
+++ b/geetools/ee_geometry.py
@@ -40,7 +40,7 @@ class GeometryAccessor:
                 multiPoly = ee.Geometry.MultiPolygon([poly0, poly1], proj="EPSG:4326")
 
                 # create a geometry collection from them
-                geometryColllection = ee.Algorithms.GeometryConstructors.MultiGeometry(
+                geometryCollection = ee.Algorithms.GeometryConstructors.MultiGeometry(
                     [multiPoly, poly0, poly1, point0, line],
                     crs="EPSG:4326",
                     geodesic=True,
@@ -48,7 +48,7 @@ class GeometryAccessor:
                 )
 
                 # extract only the LineString geometries from the collection
-                geom = geometryColllection.geetools.keepType('LineString')
+                geom = geometryCollection.geetools.keepType('LineString')
                 geom.getInfo()
         """
         # will raise an error if self is not a GeometryCollection

--- a/geetools/ee_geometry.py
+++ b/geetools/ee_geometry.py
@@ -1,4 +1,4 @@
-"""Toolbox for the ``ee.Geometry`` class."""
+"""Toolbox for the :py:class:`ee.Geometry` class."""
 from __future__ import annotations
 
 import ee
@@ -8,7 +8,7 @@ from .accessors import register_class_accessor
 
 @register_class_accessor(ee.Geometry, "geetools")
 class GeometryAccessor:
-    """Toolbox for the ``ee.Geometry`` class."""
+    """Toolbox for the :py:class:`ee.Geometry` class."""
 
     def __init__(self, obj: ee.Geometry):
         """Initialize the Geometry class."""

--- a/geetools/ee_image.py
+++ b/geetools/ee_image.py
@@ -1521,6 +1521,8 @@ class ImageAccessor:
         value = self.maskCoverRegion(region, scale, None, proxyValue, **kwargs)
         return self._obj.set(propertyName, value)
 
+    # TODO: Update this method. It throws the following error:
+    #  EEException: Image.load: Image asset 'COPERNICUS/S2_SR/20190828T151811_20190828T151809_T18GYT' not found (does not exist or caller does not have access).
     def plot(
         self,
         bands: list,
@@ -1545,7 +1547,7 @@ class ImageAccessor:
             color: The color of the overlaid feature collection. Default is "k" (black).
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
                 import matplotlib.pyplot as plt

--- a/geetools/ee_image.py
+++ b/geetools/ee_image.py
@@ -603,7 +603,7 @@ class ImageAccessor:
     ) -> ee.String:
         """Create a string from using the given pattern and using the image properties.
 
-        The ``system_date`` property is special cased to fit the dateFormat parameter.
+        The ``system_date`` property is special cased to fit the ``dateFormat`` parameter.
 
         Args:
             string: The pattern to use for the string
@@ -1055,7 +1055,7 @@ class ImageAccessor:
         """Gets the DOI of the image, if available.
 
         Returns:
-            DOI of the ee.Image dataset.
+            DOI of the ``ee.Image`` dataset.
 
         See Also:
             - :docstring:`ee.Image.geetools.getCitation`
@@ -1076,7 +1076,7 @@ class ImageAccessor:
         """Gets the citation of the image, if available.
 
         Returns:
-            Citation of the ee.Image dataset.
+            Citation of the ``ee.Image`` dataset.
 
         See Also:
             - :docstring:`ee.Image.geetools.getDOI`
@@ -1140,7 +1140,7 @@ class ImageAccessor:
         * MODIS NBAR [7]_
 
         Parameters:
-            self: ee.Image to calculate tasseled cap components for. Must belong to a supported platform.
+            self: ``ee.Image`` to calculate tasseled cap components for. Must belong to a supported platform.
 
         Returns:
             Image with the tasseled cap components as new bands.
@@ -1349,7 +1349,7 @@ class ImageAccessor:
 
         return self._obj.addBands(final)
 
-    def distance(self, other: ee.image) -> ee.Image:
+    def distance(self, other: ee.Image) -> ee.Image:
         """Compute the sum of all spectral distance between two images.
 
         Parameters:
@@ -1443,9 +1443,8 @@ class ImageAccessor:
             band: The band to use. Defaults to the first band.
             proxyValue: the value to use for counting the mask and avoid confusing 0s to masked values. In most cases the user should not change this value, but in case of conflicts, choose a value that is out of the range of the image values.
             columnName: name of the column that will hold the value.
-
-        Kwargs:
-            tileScale: A scaling factor between 0.1 and 16 used to adjust aggregation tile size; setting a larger tileScale (e.g., 2 or 4) uses smaller tiles and may enable computations that run out of memory with the default.
+            **kwargs:
+                - ``tileScale``: A scaling factor between 0.1 and 16 used to adjust aggregation tile size; setting a larger tileScale (e.g., 2 or 4) uses smaller tiles and may enable computations that run out of memory with the default.
 
         Returns:
             The passed table with the new column containing the percentage of masked pixels within the region
@@ -1499,10 +1498,9 @@ class ImageAccessor:
             scale: The scale of the computation. In case you need a rough estimation use a higher scale than the original from the image.
             proxyValue: the value to use for counting the mask and avoid confusing 0s to masked values. Choose a value that is out of the range of the image values.
             propertyName: the name of the property where the value will be saved
-
-        Kwargs:
-            maxPixels: The maximum number of pixels to reduce.
-            tileScale: A scaling factor between 0.1 and 16 used to adjust aggregation tile size; setting a larger tileScale (e.g., 2 or 4) uses smaller tiles and may enable computations that run out of memory with the default.
+            **kwargs:
+                - ``maxPixels``: The maximum number of pixels to reduce.
+                - ``tileScale``: A scaling factor between 0.1 and 16 used to adjust aggregation tile size; setting a larger tileScale (e.g., 2 or 4) uses smaller tiles and may enable computations that run out of memory with the default.
 
         Returns:
             The same image with the percentage of masked pixels as a property
@@ -1630,7 +1628,7 @@ class ImageAccessor:
             images: a list of ee.Image
 
         Returns:
-            A single ee.Image with one band per image in the passed list
+            A single ``ee.Image`` with one band per image in the passed list
 
         Examples:
             .. code-block:: python
@@ -1868,11 +1866,11 @@ class ImageAccessor:
             This method is client-side.
 
         Parameters:
-            type: The type of plot to use. Defaults to "bar". can be any type of plot from the python lib `matplotlib.pyplot`. If the one you need is missing open an issue!
+            type: The type of plot to use. Defaults to ``"bar"``. can be any type of plot from the python lib ``matplotlib.pyplot``. If the one you need is missing open an issue!
             regions: The regions to compute the reducer in.
-            reducer: The name of the reducer or a reducer object to use. Default is "mean".
+            reducer: The name of the reducer or a reducer object to use. Default is ``"mean"``.
             bands: The bands to compute the reducer on. Default to all bands.
-            regionId: The property used to label region. Defaults to "system:index".
+            regionId: The property used to label region. Defaults to ``"system:index"``.
             labels: The labels to use for the output dictionary. Default to the band names.
             colors: The colors to use for the plot. Default to the default matplotlib colors.
             ax: The matplotlib axis to plot the data on. If None, a new figure is created.
@@ -1889,7 +1887,7 @@ class ImageAccessor:
             - :docstring:`ee.Image.geetools.byRegions`
             - :docstring:`ee.Image.geetools.byBands`
             - :docstring:`ee.Image.geetools.plot_by_bands`
-            - :docstring:`ee.Image.geetools.plot_hist
+            - :docstring:`ee.Image.geetools.plot_hist`
 
         Examples:
             .. code-block:: python
@@ -1958,18 +1956,18 @@ class ImageAccessor:
 
         Each band will be plotted using the ``labels`` as x-axis label defaulting to band names if not provided.
         If no ``bands`` are provided, all bands will be plotted.
-        If no ``regionId`` are provided, the "system;index" property will be used.
+        If no ``regionId`` are provided, the ``"system:index"`` property will be used.
 
 
         Warning:
             This method is client-side.
 
         Parameters:
-            type: The type of plot to use. Defaults to "bar". can be any type of plot from the python lib `matplotlib.pyplot`. If the one you need is missing open an issue!
+            type: The type of plot to use. Defaults to "bar". can be any type of plot from the python lib ``matplotlib.pyplot``. If the one you need is missing open an issue!
             regions: The regions to compute the reducer in.
-            reducer: The name of the reducer or a reducer object to use. Default is "mean".
+            reducer: The name of the reducer or a reducer object to use. Default is ``"mean"``.
             bands: The bands to compute the reducer on. Default to all bands.
-            regionId: The property used to label region. Defaults to "system:index".
+            regionId: The property used to label region. Defaults to ``"system:index"``.
             labels: The labels to use for the output dictionary. Default to the band names.
             colors: The colors to use for the plot. Default to the default matplotlib colors.
             ax: The matplotlib axis to plot the data on. If None, a new figure is created.
@@ -2064,7 +2062,7 @@ class ImageAccessor:
             bestEffort: If the polygon would contain too many pixels at the given scale, compute and use a larger scale which would allow the operation to succeed.
             maxPixels: The maximum number of pixels to reduce. default to 10**7.
             tileScale: A scaling factor between 0.1 and 16 used to adjust aggregation tile size; setting a larger tileScale (e.g., 2 or 4) uses smaller tiles and may enable computations that run out of memory with the default.
-            kwargs: Keyword arguments passed to the matplotlib fill_between() function.
+            **kwargs: Keyword arguments passed to the `matplotlib.fill_between() <https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.fill_between.html>`_ function.
 
         Returns:
             The matplotlib axis with the plot.

--- a/geetools/ee_image.py
+++ b/geetools/ee_image.py
@@ -1557,7 +1557,7 @@ class ImageAccessor:
 
                 image = ee.Image('COPERNICUS/S2_SR/20190828T151811_20190828T151809_T18GYT')
                 fig, ax = plt.subplots()
-                image.geetools.plot(["B2", "B3", "B4"], image.geometry(), ax)
+                image.geetools.plot(["B4", "B3", "B2"], image.geometry(), ax)
         """
         if ax is None:
             fig, ax = plt.subplots()

--- a/geetools/ee_image.py
+++ b/geetools/ee_image.py
@@ -1892,7 +1892,7 @@ class ImageAccessor:
             - :docstring:`ee.Image.geetools.plot_hist
 
         Examples:
-            .. block-code:: python
+            .. code-block:: python
 
                 import ee, geetools
 

--- a/geetools/ee_image.py
+++ b/geetools/ee_image.py
@@ -2030,6 +2030,7 @@ class ImageAccessor:
 
         return ax
 
+    # TODO: Fix this example
     def plot_hist(
         self,
         bins: int = 30,
@@ -2076,7 +2077,7 @@ class ImageAccessor:
 
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 

--- a/geetools/ee_image.py
+++ b/geetools/ee_image.py
@@ -1987,7 +1987,7 @@ class ImageAccessor:
             - :docstring:`ee.Image.geetools.plot_hist`
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 

--- a/geetools/ee_image.py
+++ b/geetools/ee_image.py
@@ -1840,7 +1840,6 @@ class ImageAccessor:
                 ecoregions = ee.FeatureCollection("projects/google/charts_feature_example").select(["label", "value","warm"])
                 normClim = ee.ImageCollection('OREGONSTATE/PRISM/Norm91m').toBands()
 
-
                 normClim.plot_by_regions(ecoregions, ee.Reducer.mean(), scale=10000)
         """
         # get the data from the server
@@ -1931,7 +1930,6 @@ class ImageAccessor:
 
                 ecoregions = ee.FeatureCollection("projects/google/charts_feature_example").select(["label", "value","warm"])
                 normClim = ee.ImageCollection('OREGONSTATE/PRISM/Norm91m').toBands()
-
 
                 normClim.plot_by_bands(ecoregions, ee.Reducer.mean(), scale=10000)
         """

--- a/geetools/ee_image.py
+++ b/geetools/ee_image.py
@@ -830,6 +830,7 @@ class ImageAccessor:
         """
         return ee_extra.Spectral.core.indices()
 
+    # TODO: We can add the additional examples using https://eemont.readthedocs.io/en/latest/classes/stubs/eemont.imagecollection.spectralIndices.html
     def spectralIndices(
         self,
         index: str = "NDVI",

--- a/geetools/ee_image.py
+++ b/geetools/ee_image.py
@@ -317,7 +317,7 @@ class ImageAccessor:
             geometry: The geometry to use as reference for the grid. If None, the image footprint will be used.
 
         Returns:
-            The grid as a FeatureCollection.
+            The grid as a :py:class:`FeatureCollection`.
 
         Note:
             The method has a known bug when the projection of the image is different from 3857. As we use a buffer, the grid cells can slightly overlap. Feel free to open an Issue and contribute if you feel it needs improvements.
@@ -364,16 +364,16 @@ class ImageAccessor:
     def clipOnCollection(
         self, fc: ee.FeatureCollection, keepProperties: int | ee.Number = 1
     ) -> ee.ImageCollection:
-        """Clip an image to a FeatureCollection.
+        """Clip an image to a :py:class:`ee.FeatureCollection`.
 
-        The image will be clipped to every single features of the featureCollection as one independent image.
+        The image will be clipped to every single features of the ``featureCollection`` as one independent image.
 
         Parameters:
-            fc: The featureCollection to clip to.
-            keepProperties: If True, the properties of the featureCollection will be added to the clipped image.
+            fc: The :py:class:`ee.FeatureCollection` to clip to.
+            keepProperties: If True, the properties of the :py:class:`ee.FeatureCollection` will be added to the clipped image.
 
         Returns:
-            The clipped imageCollection.
+            The clipped :py:class:`ee.ImageCollection`.
 
         Examples:
             .. code-block:: python
@@ -443,7 +443,7 @@ class ImageAccessor:
 
         Parameters:
             values: The values to initialize the image width. If one value is given, it will be used for all bands.
-            names: The names of the bands. By default, it uses the earthen engine default value, "constant".
+            names: The names of the bands. By default, it uses the earthen engine default value, ``constant``.
 
         Returns:
             An image with the given values and names.
@@ -607,7 +607,7 @@ class ImageAccessor:
 
         Args:
             string: The pattern to use for the string
-            dateFormat: The date format to use for the system_date property
+            dateFormat: The date format to use for the ``system_date`` property
 
         Returns:
             The string corresponding to the image
@@ -643,7 +643,7 @@ class ImageAccessor:
         We apply the following function to the image:
 
         .. math::
-            \exp\left(\frac{(\text{val}-\text{mean})^2}{-2*(\text{std}^2)}\right)
+            \exp\left(\frac{(\text{val}-\text{mean})^2}{-2 \cdot (\text{std}^2)}\right)
 
         where :math:`\text{val}` is the value of the pixel, :math:`\text{mean}` is the mean of the image, :math:`\text{std}` is the standard deviation of the image.
 
@@ -749,9 +749,9 @@ class ImageAccessor:
         return ee.ImageCollection(bands.map(remove)).toBands().rename(bands)
 
     def interpolateBands(self, src: list | ee.List, to: list | ee.List) -> ee.Image:
-        """Interpolate bands from the "src" value range to the "to" value range.
+        """Interpolate bands from the ``src`` value range to the ``to`` value range.
 
-        The Interpolation is performed linearly using the "extrapolate" option of the "interpolate" method.
+        The Interpolation is performed linearly using the ``extrapolate`` option of the :py:meth:`ee.Image.interpolate` method.
 
         Args:
             src: The source value range
@@ -789,10 +789,10 @@ class ImageAccessor:
         An islet is a set of non-masked pixels connected together by their edges of very small surface. The user define the offset of the islet size, and we compute the max number of pixels to improve computation speed. The input Image needs to be a single band binary image.
 
         Args:
-            offset: The limit of the islet size in square meters
+            offset: The limit of the islet size in square meters.
 
         Returns:
-            The islet mask
+            The islet mask.
 
         Examples:
             .. code-block:: python
@@ -994,7 +994,7 @@ class ImageAccessor:
         """Pre-processes the image: masks clouds and shadows, and scales and offsets the image.
 
         Parameters:
-            **kwargs: Keywords arguments for `~.maskClouds` method.
+            **kwargs: Keywords arguments for :py:meth:`ee.Image.geetools.maskClouds <geetools.ee_image.ImageAccessor.maskClouds>` method.
 
         Returns:
             Pre-processed image.
@@ -1322,7 +1322,7 @@ class ImageAccessor:
 
         Parameters:
             mask: The mask to compute the distance to.
-            kernel: The kernel type to use for the distance computation default to "euclidean".
+            kernel: The kernel type to use for the distance computation default to ``"euclidean"``.
             radius: The radius of the kernel.
             band_name: The name of the band to store the distance values.
 
@@ -1398,7 +1398,7 @@ class ImageAccessor:
                 - ``tileScale``: A scaling factor between 0.1 and 16 used to adjust aggregation tile size; setting a larger tileScale (e.g., 2 or 4) uses smaller tiles and may enable computations that run out of memory with the default.
 
         Returns:
-            The percentage of masked pixels within the region
+            The percentage of masked pixels within the region.
 
         Examples:
             .. code-block:: python
@@ -1450,7 +1450,7 @@ class ImageAccessor:
                 - ``tileScale``: A scaling factor between 0.1 and 16 used to adjust aggregation tile size; setting a larger tileScale (e.g., 2 or 4) uses smaller tiles and may enable computations that run out of memory with the default.
 
         Returns:
-            The passed table with the new column containing the percentage of masked pixels within the region
+            The passed table with the new column containing the percentage of masked pixels within the region.
 
         Examples:
             .. code-block:: python
@@ -1506,7 +1506,7 @@ class ImageAccessor:
                 - ``tileScale``: A scaling factor between 0.1 and 16 used to adjust aggregation tile size; setting a larger tileScale (e.g., 2 or 4) uses smaller tiles and may enable computations that run out of memory with the default.
 
         Returns:
-            The same image with the percentage of masked pixels as a property
+            The same image with the percentage of masked pixels as a property.
 
         Examples:
             .. code-block:: python
@@ -1543,10 +1543,10 @@ class ImageAccessor:
             region: The geometry borders to plot the image on.
             ax: The matplotlib axis to plot the image on.
             fc: a FeatureCollection object to overlay on top of the image. Default is None, it can be a different object from the region.
-            cmap: The colormap to use for the image. Default is 'viridis'. can only ber used for single band images.
-            crs: The coordinate reference system of the image. By default, we will use EPSG:4326
+            cmap: The colormap to use for the image. Default is ``viridis``. can only ber used for single band images.
+            crs: The coordinate reference system of the image. By default, we will use ``"EPSG:4326"``
             scale: The scale of the image.
-            color: The color of the overlaid feature collection. Default is "k" (black).
+            color: The color of the overlaid feature collection. Default is ``k`` (black).
 
         Examples:
             .. code-block:: python
@@ -1686,8 +1686,8 @@ class ImageAccessor:
 
         Parameters:
             regions: The regions to compute the reducer in.
-            reducer: The name of the reducer or a reducer object to use. Default is "mean".
-            regionId: The property used to label region. Defaults to "system:index".
+            reducer: The name of the reducer or a reducer object to use. Default is ``"mean"``.
+            regionId: The property used to label region. Defaults to ``"system:index"``.
             labels: The labels to use for the output dictionary. Default to the band names.
             bands: The bands to compute the reducer on. Default to all bands.
             scale: The scale to use for the computation. Default is 10000m.
@@ -1776,8 +1776,8 @@ class ImageAccessor:
 
         Parameters:
             regions: The regions to compute the reducer in.
-            reducer: The name of the reducer or a reducer object to use. Default is "mean".
-            regionId: The property used to label region. Defaults to "system:index".
+            reducer: The name of the reducer or a reducer object to use. Default is ``"mean"``.
+            regionId: The property used to label region. Defaults to ``"system:index"``.
             labels: The labels to use for the output dictionary. Default to the band names.
             bands: The bands to compute the reducer on. Default to all bands.
             scale: The scale to use for the computation. Default is 10000m.
@@ -1966,7 +1966,7 @@ class ImageAccessor:
             This method is client-side.
 
         Parameters:
-            type: The type of plot to use. Defaults to "bar". can be any type of plot from the python lib ``matplotlib.pyplot``. If the one you need is missing open an issue!
+            type: The type of plot to use. Defaults to ``"bar"``. can be any type of plot from the python lib ``matplotlib.pyplot``. If the one you need is missing open an issue!
             regions: The regions to compute the reducer in.
             reducer: The name of the reducer or a reducer object to use. Default is ``"mean"``.
             bands: The bands to compute the reducer on. Default to all bands.

--- a/geetools/ee_image.py
+++ b/geetools/ee_image.py
@@ -900,6 +900,9 @@ class ImageAccessor:
         Returns:
             Image with the computed spectral index, or indices, as new bands.
 
+        See Also:
+            - :docstring:`ee.Image.geetools.scaleAndOffset`
+
         Examples:
             .. code-block:: python
 
@@ -923,6 +926,9 @@ class ImageAccessor:
         Returns:
             Dictionary with the scale parameters for each band.
 
+        See Also:
+            - :docstring:`ee.Image.geetools.getOffsetParams`
+            - :docstring:`ee.Image.geetools.scaleAndOffset`
 
         Examples:
             .. jupyter-execute::
@@ -942,6 +948,10 @@ class ImageAccessor:
         Returns:
             Dictionary with the offset parameters for each band.
 
+        See Also:
+            - :docstring:`ee.Image.geetools.getScaleParams`
+            - :docstring:`ee.Image.geetools.scaleAndOffset`
+
         Examples:
             .. jupyter-execute::
 
@@ -959,6 +969,10 @@ class ImageAccessor:
 
         Returns:
             Scaled image.
+
+        See Also:
+            - :docstring:`ee.Image.geetools.getScaleParams`
+            - :docstring:`ee.Image.geetools.getOffsetParams`
 
         Examples:
             .. code-block:: python
@@ -979,6 +993,12 @@ class ImageAccessor:
 
         Returns:
             Pre-processed image.
+
+        See Also:
+            - :docstring:`ee.Image.geetools.getScaleParams`
+            - :docstring:`ee.Image.geetools.getOffsetParams`
+            - :docstring:`ee.Image.geetools.scaleAndOffset`
+            - :docstring:`ee.Image.geetools.maskClouds`
 
         Examples:
             .. code-block:: python
@@ -1036,6 +1056,9 @@ class ImageAccessor:
         Returns:
             DOI of the ee.Image dataset.
 
+        See Also:
+            - :docstring:`ee.Image.geetools.getCitation`
+
         Examples:
             .. jupyter-execute::
 
@@ -1053,6 +1076,9 @@ class ImageAccessor:
 
         Returns:
             Citation of the ee.Image dataset.
+
+        See Also:
+            - :docstring:`ee.Image.geetools.getDOI`
 
         Examples:
             .. jupyter-execute::
@@ -1073,9 +1099,9 @@ class ImageAccessor:
         measure spectral distortion and set results as properties of the sharpened Image.
 
         Parameters:
-        method: The sharpening algorithm to apply. Current options are "SFIM" (Smoothing Filter-based Intensity Modulation), "HPFA" (High Pass Filter Addition), "PCS" (Principal Component Substitution), and "SM" (simple mean). Different sharpening methods will produce different quality sharpening results in different scenarios.
-        qa: One or more optional quality assessment names to apply after sharpening. Results will be stored as image properties with the pattern `geetools:metric`, e.g. `geetools:RMSE`.
-        **kwargs: Keyword arguments passed to ee.Image.reduceRegion() such as "geometry", "maxPixels", "bestEffort", etc. These arguments are only used for PCS sharpening and quality assessments.
+            method: The sharpening algorithm to apply. Current options are "SFIM" (Smoothing Filter-based Intensity Modulation), "HPFA" (High Pass Filter Addition), "PCS" (Principal Component Substitution), and "SM" (simple mean). Different sharpening methods will produce different quality sharpening results in different scenarios.
+            qa: One or more optional quality assessment names to apply after sharpening. Results will be stored as image properties with the pattern `geetools:metric`, e.g. `geetools:RMSE`.
+            **kwargs: Keyword arguments passed to ee.Image.reduceRegion() such as "geometry", "maxPixels", "bestEffort", etc. These arguments are only used for PCS sharpening and quality assessments.
 
         Returns:
             The Image with all sharpenable bands sharpened to the panchromatic resolution and quality assessments run and set as properties.
@@ -1101,22 +1127,47 @@ class ImageAccessor:
         Tasseled cap transformations are applied using coefficients published for these
         supported platforms:
 
-        * Sentinel-2 MSI Level 1C
-        * Landsat 9 OLI-2 SR
-        * Landsat 9 OLI-2 TOA
-        * Landsat 8 OLI SR
-        * Landsat 8 OLI TOA
-        * Landsat 7 ETM+ TOA
-        * Landsat 5 TM Raw DN
-        * Landsat 4 TM Raw DN
-        * Landsat 4 TM Surface Reflectance
-        * MODIS NBAR
+        * Sentinel-2 MSI Level 1C [1]_
+        * Landsat 9 OLI-2 SR [2]_
+        * Landsat 9 OLI-2 TOA [2]_
+        * Landsat 8 OLI SR [2]_
+        * Landsat 8 OLI TOA [2]_
+        * Landsat 7 ETM+ TOA [3]_
+        * Landsat 5 TM Raw DN [4]_
+        * Landsat 4 TM Raw DN [5]_
+        * Landsat 4 TM Surface Reflectance [6]_
+        * MODIS NBAR [7]_
 
         Parameters:
             self: ee.Image to calculate tasseled cap components for. Must belong to a supported platform.
 
         Returns:
             Image with the tasseled cap components as new bands.
+
+        References:
+            .. [1] Shi, T., & Xu, H. (2019). Derivation of Tasseled Cap Transformation
+                Coefficients for Sentinel-2 MSI At-Sensor Reflectance Data. IEEE Journal
+                of Selected Topics in Applied Earth Observations and Remote Sensing, 1-11.
+                doi:10.1109/jstars.2019.2938388
+            .. [2] Zhai, Y., Roy, D.P., Martins, V.S., Zhang, H.K., Yan, L., Li, Z. 2022.
+                Conterminous United States Landsat-8 top of atmosphere and surface reflectance
+                tasseled cap transformation coefficients. Remote Sensing of Environment,
+                274(2022). doi:10.1016/j.rse.2022.112992
+            .. [3] Huang, C., Wylie, B., Yang, L., Homer, C. and Zylstra, G., 2002.
+                Derivation of a tasselled cap transformation based on Landsat 7 at-satellite
+                reflectance. International journal of remote sensing, 23(8), pp.1741-1748.
+            .. [4] Crist, E.P., Laurin, R. and Cicone, R.C., 1986, September. Vegetation and
+                soils information contained in transformed Thematic Mapper data. In
+                Proceedings of IGARSS`86 symposium (pp. 1465-1470). Paris: European Space
+                Agency Publications Division.
+            .. [5] Crist, E.P. and Cicone, R.C., 1984. A physically-based transformation of
+                Thematic Mapper data---The TM Tasseled Cap. IEEE Transactions on Geoscience
+                and Remote sensing, (3), pp.256-263.
+            .. [6] Crist, E.P., 1985. A TM tasseled cap equivalent transformation for
+                reflectance factor data. Remote sensing of Environment, 17(3), pp.301-306.
+            .. [7] Lobser, S.E. and Cohen, W.B., 2007. MODIS tasselled cap: land cover
+                characteristics expressed through transformed MODIS data. International
+                Journal of Remote Sensing, 28(22), pp.5079-5101.
 
         Examples:
             .. code-block:: python
@@ -1140,10 +1191,10 @@ class ImageAccessor:
         """Adjust the image's histogram to match a target image.
 
         Parameters:
-        target: Image to match.
-        bands: A dictionary of band names to match, with source bands as keys and target bands as values.
-        geometry: The region to match histograms in that overlaps both images. If none is provided, the geometry of the source image will be used.
-        maxBuckets: The maximum number of buckets to use when building histograms. Will be rounded to the nearest power of 2.
+            target: Image to match.
+            bands: A dictionary of band names to match, with source bands as keys and target bands as values.
+            geometry: The region to match histograms in that overlaps both images. If none is provided, the geometry of the source image will be used.
+            maxBuckets: The maximum number of buckets to use when building histograms. Will be rounded to the nearest power of 2.
 
         Returns:
             The adjusted image containing the matched source bands.
@@ -1184,11 +1235,10 @@ class ImageAccessor:
         cloudDist: int = 1000,
         buffer: int = 250,
         cdi: int | None = None,
-    ):
+    ) -> ee.Image:
         """Masks clouds and shadows in an image (valid just for Surface Reflectance products).
 
         Parameters:
-            self: Image to mask.
             method: Method used to mask clouds. This parameter is ignored for Landsat products.
                 Available options:
                     - 'cloud_prob' : Use cloud probability.

--- a/geetools/ee_image.py
+++ b/geetools/ee_image.py
@@ -42,7 +42,7 @@ class ImageAccessor:
             The image with the date band added.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -79,7 +79,7 @@ class ImageAccessor:
             The image with the suffix added to the selected bands.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -110,7 +110,7 @@ class ImageAccessor:
             The image with the prefix added to the selected bands.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -141,7 +141,7 @@ class ImageAccessor:
             The image with the new band names.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -168,7 +168,7 @@ class ImageAccessor:
             The image without the specified bands.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -201,7 +201,7 @@ class ImageAccessor:
             The original image with the DOY band converted to a date band.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -239,7 +239,7 @@ class ImageAccessor:
             A dictionary with the band names and the value at the given point.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -262,7 +262,7 @@ class ImageAccessor:
             The minimum scale of the image.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -285,7 +285,7 @@ class ImageAccessor:
             The merged image.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -323,7 +323,7 @@ class ImageAccessor:
             The method has a known bug when the projection of the image is different than 3857. As we use a buffer, the grid cells can slightly overlap. Feel free to open a Issue and contribute if you feel it needs improvements.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -376,7 +376,7 @@ class ImageAccessor:
             The clipped imageCollection.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -416,7 +416,7 @@ class ImageAccessor:
             The image with the buffer mask applied.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -449,7 +449,7 @@ class ImageAccessor:
             An image with the given values and names.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -492,7 +492,7 @@ class ImageAccessor:
             An image with the same band names, projection and scale as the original image.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -548,7 +548,7 @@ class ImageAccessor:
             The image with the new reduced band added
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -581,7 +581,7 @@ class ImageAccessor:
             The image with the geometry masked.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -613,7 +613,7 @@ class ImageAccessor:
             The string corresponding to the image
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -652,7 +652,7 @@ class ImageAccessor:
             The image with the gaussian filter applied.An single band image with the gaussian filter applied.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -689,7 +689,7 @@ class ImageAccessor:
             The image with the band repeated
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -721,7 +721,7 @@ class ImageAccessor:
             The image with the zero values removed from each band.
 
         Example:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -757,7 +757,7 @@ class ImageAccessor:
             The image with the interpolated bands
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -791,7 +791,7 @@ class ImageAccessor:
             The islet mask
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -819,7 +819,7 @@ class ImageAccessor:
             List of indices implemented in this module
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -932,7 +932,7 @@ class ImageAccessor:
             - :docstring:`ee.Image.geetools.scaleAndOffset`
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee
                 import geetools
@@ -954,7 +954,7 @@ class ImageAccessor:
             - :docstring:`ee.Image.geetools.scaleAndOffset`
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee
                 import geetools
@@ -1022,7 +1022,7 @@ class ImageAccessor:
             STAC of the image.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee
                 import geetools
@@ -1061,7 +1061,7 @@ class ImageAccessor:
             - :docstring:`ee.Image.geetools.getCitation`
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee
                 import geetools
@@ -1082,7 +1082,7 @@ class ImageAccessor:
             - :docstring:`ee.Image.geetools.getDOI`
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee
                 import geetools
@@ -1633,7 +1633,7 @@ class ImageAccessor:
             A single ee.Image with one band per image in the passed list
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -1702,7 +1702,7 @@ class ImageAccessor:
             - :docstring:`ee.Image.geetools.plot_by_bands`
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -1793,7 +1793,7 @@ class ImageAccessor:
             - :docstring:`ee.Image.geetools.plot_by_regions`
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 

--- a/geetools/ee_image.py
+++ b/geetools/ee_image.py
@@ -788,7 +788,7 @@ class ImageAccessor:
             offset: The limit of the islet size in square metters
 
         Returns:
-            The island mask
+            The islet mask
 
         Examples:
             .. jupyter-execute::
@@ -799,7 +799,7 @@ class ImageAccessor:
 
                 image = ee.ImageCollection("COPERNICUS/S2_SR_HARMONIZED").first()
                 mask = image.select('SCL').eq(4)
-                mask = mask.geetools.islandMask(100)
+                mask = mask.geetools.isletMask(100)
                 print(mask.bandNames().getInfo())
         """
         offset = ee.Number(offset)

--- a/geetools/ee_image.py
+++ b/geetools/ee_image.py
@@ -839,7 +839,6 @@ class ImageAccessor:
         response.raise_for_status()
         return response.json()["SpectralIndices"]
 
-    # TODO: We can add the additional examples using https://eemont.readthedocs.io/en/latest/classes/stubs/eemont.imagecollection.spectralIndices.html
     def spectralIndices(
         self,
         index: str = "NDVI",
@@ -1532,8 +1531,6 @@ class ImageAccessor:
         value = self.maskCoverRegion(region, scale, None, proxyValue, **kwargs)
         return self._obj.set(propertyName, value)
 
-    # TODO: Update this method. It throws the following error:
-    #  EEException: Image.load: Image asset 'COPERNICUS/S2_SR/20190828T151811_20190828T151809_T18GYT' not found (does not exist or caller does not have access).
     def plot(
         self,
         bands: list,
@@ -1627,9 +1624,6 @@ class ImageAccessor:
 
         return ax
 
-    # TODO: Fix the example
-    #  Note: the second example is even correct? It seems to fail always, the error was:
-    #  EEException: Image.rename: Can't add a band named '2' to image because a band with this name already exists. Existing bands: [1, 2].
     @classmethod
     def fromList(cls, images: ee.List | list) -> ee.Image:
         """Create a single image by passing a list of images.
@@ -1852,7 +1846,6 @@ class ImageAccessor:
 
         return ee.Dictionary.fromLists(features, values)
 
-    # TODO: Fix it. Idem for plot_by_bands.
     def plot_by_regions(
         self,
         type: str,
@@ -1944,11 +1937,6 @@ class ImageAccessor:
 
         return ax
 
-    # TODO: This example throws the following error:
-    #  AttributeError: 'Reducer' object has no attribute 'aggregate_array'
-    #  That was thrown by the method byRegions, in the line:
-    #  features = regions.aggregate_array(regionId)
-    #  I think that is produced due before the method doesn't have the "type" argument
     def plot_by_bands(
         self,
         type: str,
@@ -2040,7 +2028,6 @@ class ImageAccessor:
 
         return ax
 
-    # TODO: Fix this example
     def plot_hist(
         self,
         bins: int = 30,

--- a/geetools/ee_image.py
+++ b/geetools/ee_image.py
@@ -907,7 +907,7 @@ class ImageAccessor:
 
                 ee.Initialize()
                 image = ee.Image('COPERNICUS/S2_SR/20190828T151811_20190828T151809_T18GYT')
-                image = image.specralIndices(["NDVI", "NDFI"])
+                image = image.geetools.specralIndices(["NDVI", "NDFI"])
         """
         # fmt: off
         return ee_extra.Spectral.core.spectralIndices(
@@ -950,7 +950,7 @@ class ImageAccessor:
 
                 ee.Initialize()
 
-                ee.ImageCollection('MODIS/006/MOD11A2').first().getOffsetParams()
+                ee.ImageCollection('MODIS/006/MOD11A2').first().geetools.getOffsetParams()
         """
         return ee_extra.STAC.core.getOffsetParams(self._obj)
 
@@ -967,7 +967,7 @@ class ImageAccessor:
 
                 ee.Initialize()
 
-                S2 = ee.ImageCollection('COPERNICUS/S2_SR').first().scaleAndOffset()
+                S2 = ee.ImageCollection('COPERNICUS/S2_SR').first().geetools.scaleAndOffset()
         """
         return ee_extra.STAC.core.scaleAndOffset(self._obj)
 
@@ -987,7 +987,10 @@ class ImageAccessor:
                 import geetools
 
                 ee.Initialize()
-                S2 = ee.ImageCollection('COPERNICUS/S2_SR').first().preprocess()
+                S2 = (
+                    ee.ImageCollection('COPERNICUS/S2_SR').first()
+                    .geetools.preprocess()
+                )
         """
         return ee_extra.QA.pipelines.preprocess(self._obj, **kwargs)
 
@@ -1005,7 +1008,7 @@ class ImageAccessor:
 
                 ee.Initialize()
 
-                ee.ImageCollection('COPERNICUS/S2_SR').first().getSTAC()
+                ee.ImageCollection('COPERNICUS/S2_SR').first().geetools.getSTAC()
         """
         # extract the Asset id from the imagecollection
         assetId = self._obj.get("system:id").getInfo()
@@ -1041,7 +1044,7 @@ class ImageAccessor:
 
                 ee.Initialize()
 
-                ee.ImageCollection('NASA/GPM_L3/IMERG_V06').first().getDOI()
+                ee.ImageCollection('NASA/GPM_L3/IMERG_V06').first().geetools.getDOI()
         """
         return ee_extra.STAC.core.getDOI(self._obj)
 
@@ -1059,7 +1062,7 @@ class ImageAccessor:
 
                 ee.Initialize()
 
-                ee.ImageCollection('NASA/GPM_L3/IMERG_V06').first().getCitation()
+                ee.ImageCollection('NASA/GPM_L3/IMERG_V06').first().geetools.getCitation()
         """
         return ee_extra.STAC.core.getCitation(self._obj)
 
@@ -1086,7 +1089,7 @@ class ImageAccessor:
                 ee.Initialize()
 
                 source = ee.Image("LANDSAT/LC08/C01/T1_TOA/LC08_047027_20160819")
-                sharp = source.panSharpen(method="HPFA", qa=["MSE", "RMSE"], maxPixels=1e13)
+                sharp = source.geetools.panSharpen(method="HPFA", qa=["MSE", "RMSE"], maxPixels=1e13)
         """
         return ee_extra.Algorithms.core.panSharpen(
             img=self._obj, method=method, qa=qa, prefix="geetools", **kwargs
@@ -1123,7 +1126,7 @@ class ImageAccessor:
                 ee.Initialize()
 
                 image = ee.Image('COPERNICUS/S2_SR/20190828T151811_20190828T151809_T18GYT')
-                img = img.tasseledCap()
+                img = img.geetools.tasseledCap()
         """
         return ee_extra.Spectral.core.tasseledCap(self._obj)
 
@@ -1160,7 +1163,7 @@ class ImageAccessor:
                     "B3": "B2",
                     "B2": "B1"
                 }
-                matched = source.matchHistogram(target, bands)
+                matched = source.geetools.matchHistogram(target, bands)
         """
         return ee_extra.Spectral.core.matchHistogram(
             source=self._obj,
@@ -1214,7 +1217,8 @@ class ImageAccessor:
                 S2 = (
                     ee.ImageCollection('COPERNICUS/S2_SR')
                     .first()
-                    .maskClouds(prob = 75,buffer = 300,cdi = -0.5))
+                    .geetools.maskClouds(prob = 75,buffer = 300,cdi = -0.5)
+                )
         """
         return ee_extra.QA.clouds.maskClouds(
             self._obj,
@@ -1246,7 +1250,7 @@ class ImageAccessor:
                 ee.Initialize()
 
                 image = ee.Image('COPERNICUS/S2_SR/20190828T151811_20190828T151809_T18GYT')
-                image = image.removeProperties(["system:time_start"])
+                image = image.geetools.removeProperties(["system:time_start"])
         """
         properties = ee.List(properties)
         proxy = self._obj.multiply(1)  # drop properties
@@ -1281,7 +1285,7 @@ class ImageAccessor:
                 centerBuffer = image.geometry().centroid().buffer(100)
                 BufferMask = ee.Image.constant(1).clip(centerBuffer)
                 mask = ee.Image.constant(0).where(BufferMask, 1).clip(image.geometry())
-                image = image.distanceToMask(mask)
+                image = image.geetools.distanceToMask(mask)
         """
         # gather the parameters
         kernel = getattr(ee.Kernel, kernel)(radius, "meters")
@@ -1312,7 +1316,7 @@ class ImageAccessor:
 
                 image = ee.Image('COPERNICUS/S2_SR/20190828T151811_20190828T151809_T18GYT')
                 other = ee.Image('COPERNICUS/S2_SR/20190828T151811_20190828T151809_T18GYT')
-                image = image.distance(other)
+                image = image.geetools.distance(other)
         """
         # compute the distance
         distance = self._obj.subtract(other).pow(2).reduce("sum").sqrt().rename("sum_distance")
@@ -1351,7 +1355,7 @@ class ImageAccessor:
 
                 image = ee.Image('COPERNICUS/S2_SR/20190828T151811_20190828T151809_T18GYT')
                 aoi = ee.Geometry.Point([11.880190936531116, 42.0159494554553]).buffer(2000)
-                image = image.maskCoverRegion(aoi)
+                image = image.geetools.maskCoverRegion(aoi)
         """
         # compute the mask cover
         image = self._obj.select(band or 0)
@@ -1405,7 +1409,7 @@ class ImageAccessor:
                 image = ee.Image('COPERNICUS/S2_SR/20190828T151811_20190828T151809_T18GYT')
                 reg = ee.Geometry.Point([11.880190936531116, 42.0159494554553]).buffer(2000)
                 aoi = ee.FeatureCollection([ee.Feature(reg)])
-                image = image.maskCoverRegions(aoi)
+                image = image.geetools.maskCoverRegions(aoi)
         """
         # compute the mask cover
         properties = collection.propertyNames()  # original properties
@@ -1461,7 +1465,7 @@ class ImageAccessor:
 
                 image = ee.Image('COPERNICUS/S2_SR/20190828T151811_20190828T151809_T18GYT')
                 aoi = ee.Geometry.Point([11.880190936531116, 42.0159494554553]).buffer(2000)
-                image = image.maskCoverRegion(aoi)
+                image = image.geetools.maskCoverRegion(aoi)
         """
         region = self._obj.geometry()
         value = self.maskCoverRegion(region, scale, None, proxyValue, **kwargs)
@@ -1500,7 +1504,7 @@ class ImageAccessor:
 
                 image = ee.Image('COPERNICUS/S2_SR/20190828T151811_20190828T151809_T18GYT')
                 fig, ax = plt.subplots()
-                image.plot(["B2", "B3", "B4"], image.geometry(), ax)
+                image.geetools.plot(["B2", "B3", "B4"], image.geometry(), ax)
         """
         if ax is None:
             fig, ax = plt.subplots()
@@ -1650,7 +1654,7 @@ class ImageAccessor:
 
                 ecoregions = ee.FeatureCollection("projects/google/charts_feature_example").select(["label", "value","warm"])
                 normClim = ee.ImageCollection('OREGONSTATE/PRISM/Norm91m').toBands()
-                d = normClim.byBands(ecoregions, ee.Reducer.mean(), scale=10000)
+                d = normClim.geetools.byBands(ecoregions, ee.Reducer.mean(), scale=10000)
                 print(d.getInfo())
         """
         # get all the id values, they must be string so we are forced to cast them manually
@@ -1741,7 +1745,7 @@ class ImageAccessor:
 
                 ecoregions = ee.FeatureCollection("projects/google/charts_feature_example").select(["label", "value","warm"])
                 normClim = ee.ImageCollection('OREGONSTATE/PRISM/Norm91m').toBands()
-                d = normClim.byregions(ecoregions, ee.Reducer.mean(), scale=10000)
+                d = normClim.geetools.byRegions(ecoregions, ee.Reducer.mean(), scale=10000)
                 print(d.getInfo())
         """
         # get all the id values, they must be string so we are forced to cast them manually
@@ -1840,7 +1844,7 @@ class ImageAccessor:
                 ecoregions = ee.FeatureCollection("projects/google/charts_feature_example").select(["label", "value","warm"])
                 normClim = ee.ImageCollection('OREGONSTATE/PRISM/Norm91m').toBands()
 
-                normClim.plot_by_regions(ecoregions, ee.Reducer.mean(), scale=10000)
+                normClim.geetools.plot_by_regions(ecoregions, ee.Reducer.mean(), scale=10000)
         """
         # get the data from the server
         data = self.byBands(
@@ -1931,7 +1935,7 @@ class ImageAccessor:
                 ecoregions = ee.FeatureCollection("projects/google/charts_feature_example").select(["label", "value","warm"])
                 normClim = ee.ImageCollection('OREGONSTATE/PRISM/Norm91m').toBands()
 
-                normClim.plot_by_bands(ecoregions, ee.Reducer.mean(), scale=10000)
+                normClim.geetools.plot_by_bands(ecoregions, ee.Reducer.mean(), scale=10000)
         """
         # get the data from the server
         data = self.byRegions(
@@ -2017,7 +2021,7 @@ class ImageAccessor:
                 ee.Initialize()
 
                 normClim = ee.ImageCollection('OREGONSTATE/PRISM/Norm91m').toBands()
-                normClim.plot_hist()
+                normClim.geetools.plot_hist()
         """
         # extract the bands from the image
         eeBands = ee.List(bands) if len(bands) == 0 else self._obj.bandNames()

--- a/geetools/ee_image.py
+++ b/geetools/ee_image.py
@@ -945,12 +945,12 @@ class ImageAccessor:
         Examples:
             .. jupyter-execute::
 
-            import ee
-            import geetools
+                import ee
+                import geetools
 
-            ee.Initialize()
+                ee.Initialize()
 
-            ee.ImageCollection('MODIS/006/MOD11A2').first().getOffsetParams()
+                ee.ImageCollection('MODIS/006/MOD11A2').first().getOffsetParams()
         """
         return ee_extra.STAC.core.getOffsetParams(self._obj)
 
@@ -983,11 +983,11 @@ class ImageAccessor:
         Examples:
             .. jupyter-execute::
 
-            import ee
-            import geetools
+                import ee
+                import geetools
 
-            ee.Initialize()
-            S2 = ee.ImageCollection('COPERNICUS/S2_SR').first().preprocess()
+                ee.Initialize()
+                S2 = ee.ImageCollection('COPERNICUS/S2_SR').first().preprocess()
         """
         return ee_extra.QA.pipelines.preprocess(self._obj, **kwargs)
 
@@ -1000,12 +1000,12 @@ class ImageAccessor:
         Examples:
             .. jupyter-execute::
 
-            import ee
-            import geetools
+                import ee
+                import geetools
 
-            ee.Initialize()
+                ee.Initialize()
 
-            ee.ImageCollection('COPERNICUS/S2_SR').first().getSTAC()
+                ee.ImageCollection('COPERNICUS/S2_SR').first().getSTAC()
         """
         # extract the Asset id from the imagecollection
         assetId = self._obj.get("system:id").getInfo()
@@ -1273,15 +1273,15 @@ class ImageAccessor:
         Examples:
             .. jupyter-execute::
 
-                    import ee, geetools
+                import ee, geetools
 
-                    ee.Initialize()
+                ee.Initialize()
 
-                    image = ee.Image('COPERNICUS/S2_SR/20190828T151811_20190828T151809_T18GYT')
-                    centerBuffer = image.geometry().centroid().buffer(100)
-                    BufferMask = ee.Image.constant(1).clip(centerBuffer)
-                    mask = ee.Image.constant(0).where(BufferMask, 1).clip(image.geometry())
-                    image = image.distanceToMask(mask)
+                image = ee.Image('COPERNICUS/S2_SR/20190828T151811_20190828T151809_T18GYT')
+                centerBuffer = image.geometry().centroid().buffer(100)
+                BufferMask = ee.Image.constant(1).clip(centerBuffer)
+                mask = ee.Image.constant(0).where(BufferMask, 1).clip(image.geometry())
+                image = image.distanceToMask(mask)
         """
         # gather the parameters
         kernel = getattr(ee.Kernel, kernel)(radius, "meters")
@@ -1306,13 +1306,13 @@ class ImageAccessor:
         Examples:
             .. jupyter-execute::
 
-                    import ee, geetools
+                import ee, geetools
 
-                    ee.Initialize()
+                ee.Initialize()
 
-                    image = ee.Image('COPERNICUS/S2_SR/20190828T151811_20190828T151809_T18GYT')
-                    other = ee.Image('COPERNICUS/S2_SR/20190828T151811_20190828T151809_T18GYT')
-                    image = image.distance(other)
+                image = ee.Image('COPERNICUS/S2_SR/20190828T151811_20190828T151809_T18GYT')
+                other = ee.Image('COPERNICUS/S2_SR/20190828T151811_20190828T151809_T18GYT')
+                image = image.distance(other)
         """
         # compute the distance
         distance = self._obj.subtract(other).pow(2).reduce("sum").sqrt().rename("sum_distance")
@@ -1345,13 +1345,13 @@ class ImageAccessor:
         Examples:
             .. jupyter-execute::
 
-                    import ee, geetools
+                import ee, geetools
 
-                    ee.Initialize()
+                ee.Initialize()
 
-                    image = ee.Image('COPERNICUS/S2_SR/20190828T151811_20190828T151809_T18GYT')
-                    aoi = ee.Geometry.Point([11.880190936531116, 42.0159494554553]).buffer(2000)
-                    image = image.maskCoverRegion(aoi)
+                image = ee.Image('COPERNICUS/S2_SR/20190828T151811_20190828T151809_T18GYT')
+                aoi = ee.Geometry.Point([11.880190936531116, 42.0159494554553]).buffer(2000)
+                image = image.maskCoverRegion(aoi)
         """
         # compute the mask cover
         image = self._obj.select(band or 0)
@@ -1398,14 +1398,14 @@ class ImageAccessor:
         Examples:
             .. jupyter-execute::
 
-                    import ee, geetools
+                import ee, geetools
 
-                    ee.Initialize()
+                ee.Initialize()
 
-                    image = ee.Image('COPERNICUS/S2_SR/20190828T151811_20190828T151809_T18GYT')
-                    reg = ee.Geometry.Point([11.880190936531116, 42.0159494554553]).buffer(2000)
-                    aoi = ee.FeatureCollection([ee.Feature(reg)])
-                    image = image.maskCoverRegions(aoi)
+                image = ee.Image('COPERNICUS/S2_SR/20190828T151811_20190828T151809_T18GYT')
+                reg = ee.Geometry.Point([11.880190936531116, 42.0159494554553]).buffer(2000)
+                aoi = ee.FeatureCollection([ee.Feature(reg)])
+                image = image.maskCoverRegions(aoi)
         """
         # compute the mask cover
         properties = collection.propertyNames()  # original properties
@@ -1455,13 +1455,13 @@ class ImageAccessor:
         Examples:
             .. jupyter-execute::
 
-                    import ee, geetools
+                import ee, geetools
 
-                    ee.Initialize()
+                ee.Initialize()
 
-                    image = ee.Image('COPERNICUS/S2_SR/20190828T151811_20190828T151809_T18GYT')
-                    aoi = ee.Geometry.Point([11.880190936531116, 42.0159494554553]).buffer(2000)
-                    image = image.maskCoverRegion(aoi)
+                image = ee.Image('COPERNICUS/S2_SR/20190828T151811_20190828T151809_T18GYT')
+                aoi = ee.Geometry.Point([11.880190936531116, 42.0159494554553]).buffer(2000)
+                image = image.maskCoverRegion(aoi)
         """
         region = self._obj.geometry()
         value = self.maskCoverRegion(region, scale, None, proxyValue, **kwargs)
@@ -1493,14 +1493,14 @@ class ImageAccessor:
         Examples:
             .. jupyter-execute::
 
-                    import ee, geetools
-                    import matplotlib.pyplot as plt
+                import ee, geetools
+                import matplotlib.pyplot as plt
 
-                    ee.Initialize()
+                ee.Initialize()
 
-                    image = ee.Image('COPERNICUS/S2_SR/20190828T151811_20190828T151809_T18GYT')
-                    fig, ax = plt.subplots()
-                    image.plot(["B2", "B3", "B4"], image.geometry(), ax)
+                image = ee.Image('COPERNICUS/S2_SR/20190828T151811_20190828T151809_T18GYT')
+                fig, ax = plt.subplots()
+                image.plot(["B2", "B3", "B4"], image.geometry(), ax)
         """
         if ax is None:
             fig, ax = plt.subplots()

--- a/geetools/ee_image.py
+++ b/geetools/ee_image.py
@@ -131,7 +131,7 @@ class ImageAccessor:
     def rename(self, names: dict | ee.Dictionary) -> ee.Image:
         """Rename the bands of the image based on a dictionary.
 
-        It's the same function as the one from GEE but it takes a dictionary as input.
+        It's the same function as the one from GEE, but it takes a dictionary as input.
         Keys are the old names and values are the new names.
 
         Parameters:
@@ -405,7 +405,7 @@ class ImageAccessor:
     ) -> ee.Image:
         """Make a buffer around every masked pixel of the Image.
 
-        The buffer will be made using the specified radius, kernelType and units and will mask surrounfing pixels.
+        The buffer will be made using the specified radius, kernelType and units and will mask surrounding pixels.
 
         Parameters:
             radius: The radius of the buffer.
@@ -442,8 +442,8 @@ class ImageAccessor:
         """Create an image with the given values and names.
 
         Parameters:
-            values: The values to initialize the image with. If one value is given, it will be used for all bands.
-            names: The names of the bands. By default it uses the earthen engine default value, "constant".
+            values: The values to initialize the image width. If one value is given, it will be used for all bands.
+            names: The names of the bands. By default, it uses the earthen engine default value, "constant".
 
         Returns:
             An image with the given values and names.
@@ -480,10 +480,10 @@ class ImageAccessor:
         """Create an image with the same band names, projection and scale as the original image.
 
         The projection is computed on the first band, make sure all bands have the same.
-        The procduced image can also copy the properties of the original image and keep the mask.
+        The produced image can also copy the properties of the original image and keep the mask.
 
         Parameters:
-            fillValue: The value to fill the image with.
+            fillValue: The value to fill the image width.
             copyProperties: If True, the properties of the original image will be copied to the new one.
             keepMask: If True, the mask of the original image will be copied to the new one.
             keepFootprint: If True, the footprint of the original image will be used to clip the new image.
@@ -785,7 +785,7 @@ class ImageAccessor:
         An islet is a set of non-masked pixels connected together by their edges of very small surface. The user define the offset of the island size and we compute the max number of pixels to improve computation speed. The inpt Image needs to be a single band binary image.
 
         Args:
-            offset: The limit of the islet size in square metters
+            offset: The limit of the islet size in square meters
 
         Returns:
             The islet mask
@@ -911,7 +911,7 @@ class ImageAccessor:
 
                 ee.Initialize()
                 image = ee.Image('COPERNICUS/S2_SR/20190828T151811_20190828T151809_T18GYT')
-                image = image.geetools.specralIndices(["NDVI", "NDFI"])
+                image = image.geetools.spectralIndices(["NDVI", "NDFI"])
         """
         # fmt: off
         return ee_extra.Spectral.core.spectralIndices(
@@ -1356,7 +1356,7 @@ class ImageAccessor:
             other: The image to compute the distance to.
 
         Returns:
-            and Image with the euclidean distance between the two images for each band.
+            and Image with the Euclidean distance between the two images for each band.
 
         Examples:
             .. code-block:: python
@@ -1860,7 +1860,7 @@ class ImageAccessor:
     ) -> Axes:
         """Plot the reduced values for each region.
 
-        Each region will be plotted using the ``regionId`` as x-axis label defauting to "system:index" if not provided.
+        Each region will be plotted using the ``regionId`` as x-axis label defaulting to "system:index" if not provided.
         If no ``bands`` are provided, all bands will be plotted.
         If no ``labels`` are provided, the band names will be used.
 
@@ -1870,7 +1870,7 @@ class ImageAccessor:
         Parameters:
             type: The type of plot to use. Defaults to "bar". can be any type of plot from the python lib `matplotlib.pyplot`. If the one you need is missing open an issue!
             regions: The regions to compute the reducer in.
-            rreducer: The name of the reducer or a reducer object to use. Default is "mean".
+            reducer: The name of the reducer or a reducer object to use. Default is "mean".
             bands: The bands to compute the reducer on. Default to all bands.
             regionId: The property used to label region. Defaults to "system:index".
             labels: The labels to use for the output dictionary. Default to the band names.
@@ -1956,7 +1956,7 @@ class ImageAccessor:
     ) -> Axes:
         """Plot the reduced values for each bands.
 
-        Each band will be plotted using the ``labels`` as x-axis label defauting to band names if not provided.
+        Each band will be plotted using the ``labels`` as x-axis label defaulting to band names if not provided.
         If no ``bands`` are provided, all bands will be plotted.
         If no ``regionId`` are provided, the "system;index" property will be used.
 
@@ -2056,7 +2056,7 @@ class ImageAccessor:
             bands: The bands to plot the histogram for. Default to all bands.
             labels: The labels to use for the output dictionary. Default to the band names.
             colors: The colors to use for the plot. Default to the default matplotlib colors.
-            prescision: The number of decimal to keep for the histogram bins values. Default is 2.
+            precision: The number of decimal to keep for the histogram bins values. Default is 2.
             ax: The matplotlib axis to plot the data on. If None, a new figure is created.
             scale: The scale to use for the computation. Default is 10,000m.
             crs: The projection to work in. If unspecified, the projection of the image's first band is used. If specified in addition to scale, rescaled to the specified scale.

--- a/geetools/ee_image.py
+++ b/geetools/ee_image.py
@@ -1919,7 +1919,7 @@ class ImageAccessor:
             - :docstring:`ee.Image.geetools.byRegions`
             - :docstring:`ee.Image.geetools.byBands`
             - :docstring:`ee.Image.geetools.plot_by_regions`
-            - :docstring:`ee.Image.geetools.plot_hist
+            - :docstring:`ee.Image.geetools.plot_hist`
 
         Examples:
             .. jupyter-execute::
@@ -2006,7 +2006,7 @@ class ImageAccessor:
             - :docstring:`ee.Image.geetools.byRegions`
             - :docstring:`ee.Image.geetools.byBands`
             - :docstring:`ee.Image.geetools.plot_by_bands`
-            - :docstring:`ee.Image.geetools.plot_by_regions
+            - :docstring:`ee.Image.geetools.plot_by_regions`
 
 
         Examples:

--- a/geetools/ee_image.py
+++ b/geetools/ee_image.py
@@ -1932,6 +1932,11 @@ class ImageAccessor:
 
         return ax
 
+    # TODO: This example throws the following error:
+    #  AttributeError: 'Reducer' object has no attribute 'aggregate_array'
+    #  That was throwned by the method byRegions, in the line:
+    #  features = regions.aggregate_array(regionId)
+    #  I think that is produced due before the method doesn't have the "type" argument
     def plot_by_bands(
         self,
         type: str,

--- a/geetools/ee_image.py
+++ b/geetools/ee_image.py
@@ -1842,6 +1842,7 @@ class ImageAccessor:
 
         return ee.Dictionary.fromLists(features, values)
 
+    # TODO: Fix it. Idem for plot_by_bands.
     def plot_by_regions(
         self,
         type: str,
@@ -1891,7 +1892,7 @@ class ImageAccessor:
             - :docstring:`ee.Image.geetools.plot_hist
 
         Examples:
-            .. jupyter-execute::
+            .. block-code:: python
 
                 import ee, geetools
 

--- a/geetools/ee_image.py
+++ b/geetools/ee_image.py
@@ -32,7 +32,7 @@ class ImageAccessor:
     def addDate(self, format: str | ee.String = "") -> ee.Image:
         """Add a band with the date of the image in the provided format.
 
-        If no format is provided, the date is stored as a Timestamp in millisecond in a band "date". If format band is provided, the date is store in a int8 band with the date in the provided format. This format needs to be a string that can be converted to a number.
+        If no format is provided, the date is stored as a Timestamp in millisecond in a band "date". If format band is provided, the date is store in an int8 band with the date in the provided format. This format needs to be a string that can be converted to a number.
         If not an error will be thrown.
 
         Args:
@@ -320,7 +320,7 @@ class ImageAccessor:
             The grid as a FeatureCollection.
 
         Note:
-            The method has a known bug when the projection of the image is different than 3857. As we use a buffer, the grid cells can slightly overlap. Feel free to open a Issue and contribute if you feel it needs improvements.
+            The method has a known bug when the projection of the image is different from 3857. As we use a buffer, the grid cells can slightly overlap. Feel free to open an Issue and contribute if you feel it needs improvements.
 
         Examples:
             .. code-block:: python
@@ -649,7 +649,7 @@ class ImageAccessor:
             band: The band to apply the gaussian filter to. If empty, the first one is selected.
 
         Returns:
-            The image with the gaussian filter applied.An single band image with the gaussian filter applied.
+            The image with the gaussian filter applied. A single band image with the gaussian filter applied.
 
         Examples:
             .. code-block:: python
@@ -782,7 +782,7 @@ class ImageAccessor:
     def isletMask(self, offset: float | int | ee.Number) -> ee.Image:
         """Compute the islet mask from an image.
 
-        An islet is a set of non-masked pixels connected together by their edges of very small surface. The user define the offset of the island size and we compute the max number of pixels to improve computation speed. The inpt Image needs to be a single band binary image.
+        An islet is a set of non-masked pixels connected together by their edges of very small surface. The user define the offset of the islet size, and we compute the max number of pixels to improve computation speed. The input Image needs to be a single band binary image.
 
         Args:
             offset: The limit of the islet size in square meters
@@ -881,7 +881,7 @@ class ImageAccessor:
             slope: Soil line slope, default = 1.0
             intercept: Soil line intercept, default = 0.0
             gamma: Weighting coefficient used for ARVI, default = 1.0
-            omega: Weighting coefficient  used for MBWI, default = 2.0
+            omega: Weighting coefficient used for MBWI, default = 2.0
             beta: Calibration parameter used for NDSIns, default = 0.05
             k: Slope parameter by soil used for NIRvH2, default = 0.0
             fdelta: Adjustment factor used for SEVI, default = 0.581
@@ -1543,7 +1543,7 @@ class ImageAccessor:
             ax: The matplotlib axis to plot the image on.
             fc: a FeatureCollection object to overlay on top of the image. Default is None, it can be a different object from the region.
             cmap: The colormap to use for the image. Default is 'viridis'. can only ber used for single band images.
-            crs: The coordinate reference system of the image. by default we will use EPSG:4326
+            crs: The coordinate reference system of the image. By default, we will use EPSG:4326
             scale: The scale of the image.
             color: The color of the overlaid feature collection. Default is "k" (black).
 
@@ -1936,7 +1936,7 @@ class ImageAccessor:
 
     # TODO: This example throws the following error:
     #  AttributeError: 'Reducer' object has no attribute 'aggregate_array'
-    #  That was throwned by the method byRegions, in the line:
+    #  That was thrown by the method byRegions, in the line:
     #  features = regions.aggregate_array(regionId)
     #  I think that is produced due before the method doesn't have the "type" argument
     def plot_by_bands(
@@ -1954,7 +1954,7 @@ class ImageAccessor:
         crsTransform: list | None = None,
         tileScale: float = 1,
     ) -> Axes:
-        """Plot the reduced values for each bands.
+        """Plot the reduced values for each band.
 
         Each band will be plotted using the ``labels`` as x-axis label defaulting to band names if not provided.
         If no ``bands`` are provided, all bands will be plotted.

--- a/geetools/ee_image.py
+++ b/geetools/ee_image.py
@@ -1614,6 +1614,9 @@ class ImageAccessor:
 
         return ax
 
+    # TODO: Fix the example
+    #  Note: the second example is even correct? It seems to fail always, the error was:
+    #  EEException: Image.rename: Can't add a band named '2' to image because a band with this name already exists. Existing bands: [1, 2].
     @classmethod
     def fromList(cls, images: ee.List | list):
         """Create a single image by passing a list of images.
@@ -1638,7 +1641,7 @@ class ImageAccessor:
                 image = ee.Image.geetools.fromList(images)
                 print(image.bandNames().getInfo())
 
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 

--- a/geetools/ee_image.py
+++ b/geetools/ee_image.py
@@ -1594,7 +1594,6 @@ class ImageAccessor:
                 images = sequence.map(lambda i: ee.Image(ee.Number(i)).rename(ee.Number(i).int().format()))
                 image = ee.Image.geetools.fromList(images)
                 print(image.bandNames().getInfo())
-            > ee.ee_exception.EEException: Image.rename: Can't add a band named '2' to image because a band with this name already exists. Existing bands: [1, 2].
         """
         bandNames = ee.List(images).map(lambda i: ee.Image(i).bandNames()).flatten()
         ic = ee.ImageCollection.fromImages(images)

--- a/geetools/ee_image.py
+++ b/geetools/ee_image.py
@@ -42,7 +42,7 @@ class ImageAccessor:
             The image with the date band added.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -79,7 +79,7 @@ class ImageAccessor:
             The image with the suffix added to the selected bands.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -110,7 +110,7 @@ class ImageAccessor:
             The image with the prefix added to the selected bands.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -141,7 +141,7 @@ class ImageAccessor:
             The image with the new band names.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -168,7 +168,7 @@ class ImageAccessor:
             The image without the specified bands.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -201,7 +201,7 @@ class ImageAccessor:
             The original image with the DOY band converted to a date band.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -239,7 +239,7 @@ class ImageAccessor:
             A dictionary with the band names and the value at the given point.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -262,7 +262,7 @@ class ImageAccessor:
             The minimum scale of the image.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -285,7 +285,7 @@ class ImageAccessor:
             The merged image.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -323,7 +323,7 @@ class ImageAccessor:
             The method has a known bug when the projection of the image is different than 3857. As we use a buffer, the grid cells can slightly overlap. Feel free to open a Issue and contribute if you feel it needs improvements.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -376,7 +376,7 @@ class ImageAccessor:
             The clipped imageCollection.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -416,7 +416,7 @@ class ImageAccessor:
             The image with the buffer mask applied.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -449,7 +449,7 @@ class ImageAccessor:
             An image with the given values and names.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -492,7 +492,7 @@ class ImageAccessor:
             An image with the same band names, projection and scale as the original image.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -548,7 +548,7 @@ class ImageAccessor:
             The image with the new reduced band added
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -581,7 +581,7 @@ class ImageAccessor:
             The image with the geometry masked.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -613,7 +613,7 @@ class ImageAccessor:
             The string corresponding to the image
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -652,7 +652,7 @@ class ImageAccessor:
             The image with the gaussian filter applied.An single band image with the gaussian filter applied.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -689,7 +689,7 @@ class ImageAccessor:
             The image with the band repeated
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -721,7 +721,7 @@ class ImageAccessor:
             The image with the zero values removed from each band.
 
         Example:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -757,7 +757,7 @@ class ImageAccessor:
             The image with the interpolated bands
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -791,7 +791,7 @@ class ImageAccessor:
             The island mask
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -819,7 +819,7 @@ class ImageAccessor:
             List of indices implemented in this module
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -901,7 +901,7 @@ class ImageAccessor:
             Image with the computed spectral index, or indices, as new bands.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -925,7 +925,7 @@ class ImageAccessor:
 
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee
                 import geetools
@@ -943,7 +943,7 @@ class ImageAccessor:
             Dictionary with the offset parameters for each band.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
             import ee
             import geetools
@@ -961,7 +961,7 @@ class ImageAccessor:
             Scaled image.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -981,7 +981,7 @@ class ImageAccessor:
             Pre-processed image.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
             import ee
             import geetools
@@ -998,7 +998,7 @@ class ImageAccessor:
             STAC of the image.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
             import ee
             import geetools
@@ -1034,7 +1034,7 @@ class ImageAccessor:
             DOI of the ee.Image dataset.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee
                 import geetools
@@ -1052,7 +1052,7 @@ class ImageAccessor:
             Citation of the ee.Image dataset.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee
                 import geetools
@@ -1078,7 +1078,7 @@ class ImageAccessor:
             The Image with all sharpenable bands sharpened to the panchromatic resolution and quality assessments run and set as properties.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee
                 import geetools
@@ -1116,7 +1116,7 @@ class ImageAccessor:
             Image with the tasseled cap components as new bands.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -1146,7 +1146,7 @@ class ImageAccessor:
             The adjusted image containing the matched source bands.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee
                 import geetools
@@ -1206,7 +1206,7 @@ class ImageAccessor:
             This method may mask water as well as clouds for the Sentinel-3 Radiance product.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -1239,7 +1239,7 @@ class ImageAccessor:
             Image with the specified properties removed.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -1271,7 +1271,7 @@ class ImageAccessor:
             The original images with the distance band added.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                     import ee, geetools
 
@@ -1304,7 +1304,7 @@ class ImageAccessor:
             and Image with the euclidean distance between the two images for each band.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                     import ee, geetools
 
@@ -1343,7 +1343,7 @@ class ImageAccessor:
             The percentage of masked pixels within the region
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                     import ee, geetools
 
@@ -1396,7 +1396,7 @@ class ImageAccessor:
             The passed table with the new column containing the percentage of masked pixels within the region
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                     import ee, geetools
 
@@ -1453,7 +1453,7 @@ class ImageAccessor:
             The same image with the percentage of masked pixels as a property
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                     import ee, geetools
 
@@ -1491,7 +1491,7 @@ class ImageAccessor:
             color: The color of the overlaid feature collection. Default is "k" (black).
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                     import ee, geetools
                     import matplotlib.pyplot as plt
@@ -1573,7 +1573,7 @@ class ImageAccessor:
             A single ee.Image with one band per image in the passed list
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -1584,7 +1584,7 @@ class ImageAccessor:
                 image = ee.Image.geetools.fromList(images)
                 print(image.bandNames().getInfo())
 
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -1643,7 +1643,7 @@ class ImageAccessor:
             - :docstring:`ee.Image.geetools.plot_by_bands`
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -1734,7 +1734,7 @@ class ImageAccessor:
             - :docstring:`ee.Image.geetools.plot_by_regions`
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -1832,7 +1832,7 @@ class ImageAccessor:
             - :docstring:`ee.Image.geetools.plot_hist
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -1924,7 +1924,7 @@ class ImageAccessor:
             - :docstring:`ee.Image.geetools.plot_hist
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -2013,7 +2013,7 @@ class ImageAccessor:
 
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 

--- a/geetools/ee_image.py
+++ b/geetools/ee_image.py
@@ -227,7 +227,7 @@ class ImageAccessor:
 
     # -- the rest --------------------------------------------------------------
 
-    def getValues(self, point: ee.Geometry.Point, scale: int | ee.Number = 0) -> ee.Dictionary:
+    def getValues(self, point: ee.Geometry, scale: int | ee.Number = 0) -> ee.Dictionary:
         """Get the value of the image at the given point using specified geometry.
 
         The result is presented as a dictionary where the keys are the bands name and the value the mean value of the band at the given point.
@@ -1621,7 +1621,7 @@ class ImageAccessor:
     #  Note: the second example is even correct? It seems to fail always, the error was:
     #  EEException: Image.rename: Can't add a band named '2' to image because a band with this name already exists. Existing bands: [1, 2].
     @classmethod
-    def fromList(cls, images: ee.List | list):
+    def fromList(cls, images: ee.List | list) -> ee.Image:
         """Create a single image by passing a list of images.
 
         Warning: The bands cannot have repeated names, if so, it will throw an error (see examples).
@@ -1661,7 +1661,7 @@ class ImageAccessor:
 
     def byBands(
         self,
-        regions: ee.featurecollection,
+        regions: ee.FeatureCollection,
         reducer: str | ee.Reducer = "mean",
         bands: list = [],
         regionId: str = "system:index",
@@ -1751,7 +1751,7 @@ class ImageAccessor:
 
     def byRegions(
         self,
-        regions: ee.featurecollection,
+        regions: ee.FeatureCollection,
         reducer: str | ee.Reducer = "mean",
         bands: list = [],
         regionId: str = "system:index",

--- a/geetools/ee_image.py
+++ b/geetools/ee_image.py
@@ -823,7 +823,7 @@ class ImageAccessor:
 
                 import ee, geetools
 
-                ind = ee.Image.geetools.indices()["BAIS2"]
+                ind = ee.Image.geetools.index_list()["BAIS2"]
                 print(ind["long_name"])
                 print(ind["formula"])
                 print(ind["reference"])

--- a/geetools/ee_image.py
+++ b/geetools/ee_image.py
@@ -901,7 +901,7 @@ class ImageAccessor:
             Image with the computed spectral index, or indices, as new bands.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -961,7 +961,7 @@ class ImageAccessor:
             Scaled image.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -981,7 +981,7 @@ class ImageAccessor:
             Pre-processed image.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee
                 import geetools
@@ -1078,7 +1078,7 @@ class ImageAccessor:
             The Image with all sharpenable bands sharpened to the panchromatic resolution and quality assessments run and set as properties.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee
                 import geetools
@@ -1116,7 +1116,7 @@ class ImageAccessor:
             Image with the tasseled cap components as new bands.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -1146,7 +1146,7 @@ class ImageAccessor:
             The adjusted image containing the matched source bands.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee
                 import geetools
@@ -1206,7 +1206,7 @@ class ImageAccessor:
             This method may mask water as well as clouds for the Sentinel-3 Radiance product.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -1239,7 +1239,7 @@ class ImageAccessor:
             Image with the specified properties removed.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -1271,7 +1271,7 @@ class ImageAccessor:
             The original images with the distance band added.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -1304,7 +1304,7 @@ class ImageAccessor:
             and Image with the euclidean distance between the two images for each band.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -1343,7 +1343,7 @@ class ImageAccessor:
             The percentage of masked pixels within the region
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -1396,7 +1396,7 @@ class ImageAccessor:
             The passed table with the new column containing the percentage of masked pixels within the region
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -1453,7 +1453,7 @@ class ImageAccessor:
             The same image with the percentage of masked pixels as a property
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 

--- a/geetools/ee_image.py
+++ b/geetools/ee_image.py
@@ -1,4 +1,4 @@
-"""Toolbox for the ``ee.Image`` class."""
+"""Toolbox for the :py:class:`ee.Image` class."""
 from __future__ import annotations
 
 from typing import Any, Optional
@@ -22,7 +22,7 @@ from .utils import plot_data
 
 @register_class_accessor(ee.Image, "geetools")
 class ImageAccessor:
-    """Toolbox for the ``ee.Image`` class."""
+    """Toolbox for the :py:class:`ee.Image` class."""
 
     def __init__(self, obj: ee.Image):
         """Initialize the Image class."""
@@ -184,7 +184,7 @@ class ImageAccessor:
 
     def doyToDate(
         self,
-        year,
+        year: int | float | ee.Number,
         dateFormat: str | ee.String = "yyyyMMdd",
         band: str | ee.String = "",
     ) -> ee.Image:
@@ -638,10 +638,14 @@ class ImageAccessor:
         return patternList.iterate(replaceProperties, string)
 
     def gauss(self, band: str | ee.String = "") -> ee.Image:
-        """Apply a gaussian filter to the image.
+        r"""Apply a gaussian filter to the image.
 
-        We apply the following function to the image: "exp(((val-mean)**2)/(-2*(std**2)))"
-        where val is the value of the pixel, mean is the mean of the image, std is the standard deviation of the image.
+        We apply the following function to the image:
+
+        .. math::
+            \exp\left(\frac{(\text{val}-\text{mean})^2}{-2*(\text{std}^2)}\right)
+
+        where :math:`\text{val}` is the value of the pixel, :math:`\text{mean}` is the mean of the image, :math:`\text{std}` is the standard deviation of the image.
 
         See the `Gaussian filter <https://en.wikipedia.org/wiki/Gaussian_function>`_ Wikipedia page for more information.
 
@@ -990,7 +994,7 @@ class ImageAccessor:
         """Pre-processes the image: masks clouds and shadows, and scales and offsets the image.
 
         Parameters:
-            **kwargs: Keywords arguments for ``maskClouds`` method.
+            **kwargs: Keywords arguments for `~.maskClouds` method.
 
         Returns:
             Pre-processed image.
@@ -1055,7 +1059,7 @@ class ImageAccessor:
         """Gets the DOI of the image, if available.
 
         Returns:
-            DOI of the ``ee.Image`` dataset.
+            DOI of the :py:class:`ee.Image` dataset.
 
         See Also:
             - :docstring:`ee.Image.geetools.getCitation`
@@ -1076,7 +1080,7 @@ class ImageAccessor:
         """Gets the citation of the image, if available.
 
         Returns:
-            Citation of the ``ee.Image`` dataset.
+            Citation of the :py:class:`ee.Image` dataset.
 
         See Also:
             - :docstring:`ee.Image.geetools.getDOI`
@@ -1140,7 +1144,7 @@ class ImageAccessor:
         * MODIS NBAR [7]_
 
         Parameters:
-            self: ``ee.Image`` to calculate tasseled cap components for. Must belong to a supported platform.
+            self: :py:class:`ee.Image` to calculate tasseled cap components for. Must belong to a supported platform.
 
         Returns:
             Image with the tasseled cap components as new bands.
@@ -1389,10 +1393,9 @@ class ImageAccessor:
             scale: The scale of the computation. In case you need a rough estimation use a higher scale than the original from the image.
             band: The band to use. Defaults to the first band.
             proxyValue: the value to use for counting the mask and avoid confusing 0s to masked values. In most cases the user should not change this value, but in case of conflicts, choose a value that is out of the range of the image values.
-
-        Kwargs:
-            maxPixels: The maximum number of pixels to reduce.
-            tileScale: A scaling factor between 0.1 and 16 used to adjust aggregation tile size; setting a larger tileScale (e.g., 2 or 4) uses smaller tiles and may enable computations that run out of memory with the default.
+            **kwargs:
+                - ``maxPixels``: The maximum number of pixels to reduce.
+                - ``tileScale``: A scaling factor between 0.1 and 16 used to adjust aggregation tile size; setting a larger tileScale (e.g., 2 or 4) uses smaller tiles and may enable computations that run out of memory with the default.
 
         Returns:
             The percentage of masked pixels within the region
@@ -1628,7 +1631,7 @@ class ImageAccessor:
             images: a list of ee.Image
 
         Returns:
-            A single ``ee.Image`` with one band per image in the passed list
+            A single :py:class:`ee.Image` with one band per image in the passed list
 
         Examples:
             .. code-block:: python

--- a/geetools/ee_image.py
+++ b/geetools/ee_image.py
@@ -1,7 +1,7 @@
 """Toolbox for the ``ee.Image`` class."""
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Optional
 
 import ee
 import ee_extra
@@ -812,7 +812,7 @@ class ImageAccessor:
         return isletArea.lt(offset).rename("mask").selfMask()
 
     # -- ee-extra wrapper ------------------------------------------------------
-    def index_list(cls) -> dict:
+    def index_list(cls) -> dict[str, dict]:
         """Return the list of indices implemented in this module.
 
         Returns:
@@ -921,7 +921,7 @@ class ImageAccessor:
         )
         # fmt: on
 
-    def getScaleParams(self) -> dict:
+    def getScaleParams(self) -> dict[str, float]:
         """Gets the scale parameters for each band of the image.
 
         Returns:
@@ -943,7 +943,7 @@ class ImageAccessor:
         """
         return ee_extra.STAC.core.getScaleParams(self._obj)
 
-    def getOffsetParams(self) -> dict:
+    def getOffsetParams(self) -> dict[str, float]:
         """Gets the offset parameters for each band of the image.
 
         Returns:
@@ -1015,7 +1015,7 @@ class ImageAccessor:
         """
         return ee_extra.QA.pipelines.preprocess(self._obj, **kwargs)
 
-    def getSTAC(self) -> dict:
+    def getSTAC(self) -> dict[str, Any]:
         """Gets the STAC of the image.
 
         Returns:

--- a/geetools/ee_image.py
+++ b/geetools/ee_image.py
@@ -97,7 +97,7 @@ class ImageAccessor:
         )
         return self._obj.rename(bandNames)
 
-    def addPrefix(self, prefix: str | ee.String, bands: list | ee.List = []):
+    def addPrefix(self, prefix: str | ee.String, bands: list | ee.List = []) -> ee.Image:
         """Add a prefix to the image selected band.
 
         Add a prefix to the selected band. If no band is specified, the prefix is added to all bands.
@@ -678,7 +678,7 @@ class ImageAccessor:
             },
         ).rename(band.cat("_gauss"))
 
-    def repeat(self, band, repeats: int | ee.Number) -> ee.image:
+    def repeat(self, band, repeats: int | ee.Number) -> ee.Image:
         """Repeat a band of the image.
 
         Args:

--- a/geetools/ee_image_collection.py
+++ b/geetools/ee_image_collection.py
@@ -1116,6 +1116,7 @@ class ImageCollectionAccessor:
 
         return ee.Image(medoid).select(bandNames)
 
+    # TODO: Fix the example
     def datesByBands(
         self,
         region: ee.Geometry,
@@ -1164,7 +1165,7 @@ class ImageCollectionAccessor:
             - :docstring:`ee.ImageCollection.geetools.plot_doy_by_regions`
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 

--- a/geetools/ee_image_collection.py
+++ b/geetools/ee_image_collection.py
@@ -282,7 +282,7 @@ class ImageCollectionAccessor:
 
                 ee.Initialize()
 
-                S2 = ee.ImageCollection('COPERNICUS/S2_SR_HARMONIZED').scaleAndOffset()
+                S2 = ee.ImageCollection('COPERNICUS/S2_SR').scaleAndOffset()
         """
         return ee_extra.STAC.core.scaleAndOffset(self._obj)
 
@@ -308,7 +308,7 @@ class ImageCollectionAccessor:
                 import geetools
 
                 ee.Initialize()
-                S2 = ee.ImageCollection('COPERNICUS/S2_SR_HARMONIZED').preprocess()
+                S2 = ee.ImageCollection('COPERNICUS/S2_SR').preprocess()
         """
         return ee_extra.QA.pipelines.preprocess(self._obj, **kwargs)
 
@@ -326,7 +326,7 @@ class ImageCollectionAccessor:
 
                 ee.Initialize()
 
-                ee.ImageCollection('COPERNICUS/S2_SR_HARMONIZED').geetools.getSTAC()
+                ee.ImageCollection('COPERNICUS/S2_SR').geetools.getSTAC()
         """
         # extract the Asset id from the imagecollection
         assetId = self._obj.get("system:id").getInfo()
@@ -496,7 +496,7 @@ class ImageCollectionAccessor:
 
                 ee.Initialize()
 
-                ic = ee.ImageCollection('COPERNICUS/S2_SR_HARMONIZED');
+                ic = ee.ImageCollection('COPERNICUS/S2_SR');
 
                 geom = ee.Geometry.Point(-122.196, 41.411);
                 ic2018 = ic.filterBounds(geom).filterDate('2019-07-01', '2019-10-01')
@@ -520,7 +520,7 @@ class ImageCollectionAccessor:
 
                 ee.Initialize()
 
-                ic = ee.ImageCollection('COPERNICUS/S2_SR_HARMONIZED');
+                ic = ee.ImageCollection('COPERNICUS/S2_SR');
 
                 geom = ee.Geometry.Point(-122.196, 41.411);
                 ic2018 = ic.filterBounds(geom).filterDate('2019-07-01', '2019-10-01')
@@ -546,7 +546,7 @@ class ImageCollectionAccessor:
 
                 ee.Initialize()
 
-                ic = ee.ImageCollection('COPERNICUS/S2_SR_HARMONIZED');
+                ic = ee.ImageCollection('COPERNICUS/S2_SR');
 
                 geom = ee.Geometry.Point(-122.196, 41.411);
                 ic2018 = ic.filterBounds(geom).filterDate('2019-07-01', '2019-10-01')

--- a/geetools/ee_image_collection.py
+++ b/geetools/ee_image_collection.py
@@ -556,7 +556,7 @@ class ImageCollectionAccessor:
         Examples:
             .. jupyter-execute::
 
-                import ee, LDCGEETools
+                import ee, geetools
 
                 collection = (
                     ee.ImageCollection("LANDSAT/LC08/C01/T1_TOA")
@@ -641,7 +641,7 @@ class ImageCollectionAccessor:
         Examples:
             .. jupyter-execute::
 
-                import ee, LDCGEETools
+                import ee, geetools
 
                 collection = (
                     ee.ImageCollection("LANDSAT/LC08/C01/T1_TOA")
@@ -761,14 +761,14 @@ class ImageCollectionAccessor:
         Examples:
             .. jupyter-execute::
 
-                import ee, LDCGEETools
+                import ee, geetools
                 collection = (
                     ee.ImageCollection("LANDSAT/LC08/C01/T1_TOA")
                     .filterBounds(ee.Geometry.Point(-122.262, 37.8719))
                     .filterDate("2014-01-01", "2014-12-31")
                 )
                 valid = collection.geetools.validPixels("B1")
-                print(valid.getInfo()).
+                print(valid.getInfo())
         """
         # compute the mask for the specified band
         band = self._obj.first().bandNames().get(0) if band == "" else ee.String(band)
@@ -790,7 +790,7 @@ class ImageCollectionAccessor:
         Examples:
             .. jupyter-execute::
 
-                import ee, LDCGEETools
+                import ee, geetools
 
                 collection = (
                     ee.ImageCollection("LANDSAT/LC08/C01/T1_TOA")

--- a/geetools/ee_image_collection.py
+++ b/geetools/ee_image_collection.py
@@ -122,7 +122,7 @@ class ImageCollectionAccessor:
         """
         return ee_extra.ImageCollection.core.closest(self._obj, date, tolerance, unit)
 
-    # TODO: We can add the additional examples in https://eemont.readthedocs.io/en/latest/classes/stubs/eemont.imagecollection.spectralIndices.html
+    # TODO: We can add the additional examples using https://eemont.readthedocs.io/en/latest/classes/stubs/eemont.imagecollection.spectralIndices.html
     def spectralIndices(
         self,
         index: str = "NDVI",

--- a/geetools/ee_image_collection.py
+++ b/geetools/ee_image_collection.py
@@ -99,6 +99,7 @@ class ImageCollectionAccessor:
         """Gets the closest image (or set of images if the collection intersects a region that requires multiple scenes) to the specified date.
 
         Parameters:
+            self: Image Collection from which to get the closest image to the specified date.
             date: Date of interest. The method will look for images closest to this date.
             tolerance: Filter the collection to [date - tolerance, date + tolerance) before searching the closest image. This speeds up the searching process for collections with a high temporal resolution.
             unit: Units for tolerance. Available units: 'year', 'month', 'week', 'day', 'hour', 'minute' or 'second'.
@@ -112,11 +113,12 @@ class ImageCollectionAccessor:
                 import ee
                 import geetools
 
-                s2 = ee.ImageCollection('COPERNICUS/S2_SR').closest('2020-10-15')
+                s2 = ee.ImageCollection('COPERNICUS/S2_SR').geetools.closest('2020-10-15')
                 s2.size().getInfo()
         """
         return ee_extra.ImageCollection.core.closest(self._obj, date, tolerance, unit)
 
+    # TODO: We can add the additional examples in https://eemont.readthedocs.io/en/latest/classes/stubs/eemont.imagecollection.spectralIndices.html
     def spectralIndices(
         self,
         index: str = "NDVI",
@@ -143,7 +145,7 @@ class ImageCollectionAccessor:
         lambdaG: float | int = 555.0,
         online: bool = False,
     ) -> ee.ImageCollection:
-        """Computes one or more spectral indices (indices are added as bands) for an image from the Awesome List of Spectral Indices.
+        """Computes one or more spectral indices (indices are added as bands) for an image collection from the Awesome List of Spectral Indices.
 
         Parameters:
             self: Image to compute indices on. Must be scaled to [0,1].
@@ -185,7 +187,10 @@ class ImageCollectionAccessor:
             drop: Whether to drop all bands except the new spectral indices, default = False
 
         Returns:
-            Image with the computed spectral index, or indices, as new bands.
+            Image collection with the computed spectral index, or indices, as new bands.
+
+        See Also:
+            - :docstring:`ee.Image.geetools.scaleAndOffset`
 
         Examples:
             .. code-block:: python
@@ -210,6 +215,9 @@ class ImageCollectionAccessor:
         Returns:
             Dictionary with the scale parameters for each band.
 
+        See Also:
+            - :docstring:`ee.ImageCollection.geetools.getOffsetParams`
+            - :docstring:`ee.ImageCollection.geetools.scaleAndOffset`
 
         Examples:
             .. jupyter-execute::
@@ -229,6 +237,10 @@ class ImageCollectionAccessor:
         Returns:
             Dictionary with the offset parameters for each band.
 
+        See Also:
+            - :docstring:`ee.ImageCollection.geetools.getScaleParams`
+            - :docstring:`ee.ImageCollection.geetools.scaleAndOffset`
+
         Examples:
             .. jupyter-execute::
 
@@ -237,7 +249,7 @@ class ImageCollectionAccessor:
 
                 ee.Initialize()
 
-                ee.ImageCollection('MODIS/006/MOD11A2').getOffsetParams()
+                ee.ImageCollection('MODIS/006/MOD11A2').geetools.getOffsetParams()
         """
         return ee_extra.STAC.core.getOffsetParams(self._obj)
 
@@ -246,6 +258,10 @@ class ImageCollectionAccessor:
 
         Returns:
             Scaled image.
+
+        See Also:
+            - :docstring:`ee.ImageCollection.geetools.getOffsetParams`
+            - :docstring:`ee.ImageCollection.geetools.getScaleParams`
 
         Examples:
             .. code-block:: python
@@ -259,13 +275,19 @@ class ImageCollectionAccessor:
         return ee_extra.STAC.core.scaleAndOffset(self._obj)
 
     def preprocess(self, **kwargs) -> ee.ImageCollection:
-        """Pre-processes the image: masks clouds and shadows, and scales and offsets the image.
+        """Pre-processes the image: masks clouds and shadows, and scales and offsets the image collection.
 
         Parameters:
             **kwargs: Keywords arguments for ``maskClouds`` method.
 
         Returns:
             Pre-processed image.
+
+        See Also:
+            - :docstring:`ee.ImageCollection.geetools.getScaleParams`
+            - :docstring:`ee.ImageCollection.geetools.getOffsetParams`
+            - :docstring:`ee.ImageCollection.geetools.scaleAndOffset`
+            - :docstring:`ee.ImageCollection.geetools.maskClouds`
 
         Examples:
             .. code-block:: python
@@ -279,10 +301,10 @@ class ImageCollectionAccessor:
         return ee_extra.QA.pipelines.preprocess(self._obj, **kwargs)
 
     def getSTAC(self) -> dict:
-        """Gets the STAC of the image.
+        """Gets the STAC of the image collection.
 
         Returns:
-            STAC of the image.
+            STAC of the image collection.
 
         Examples:
             .. jupyter-execute::
@@ -292,7 +314,7 @@ class ImageCollectionAccessor:
 
                 ee.Initialize()
 
-                ee.ImageCollection('COPERNICUS/S2_SR').getSTAC()
+                ee.ImageCollection('COPERNICUS/S2_SR').geetools.getSTAC()
         """
         # extract the Asset id from the imagecollection
         assetId = self._obj.get("system:id").getInfo()
@@ -320,6 +342,9 @@ class ImageCollectionAccessor:
         Returns:
             DOI of the ee.Image dataset.
 
+        See Also:
+            - :docstring:`ee.ImageCollection.geetools.getCitation`
+
         Examples:
             .. jupyter-execute::
 
@@ -328,7 +353,7 @@ class ImageCollectionAccessor:
 
                 ee.Initialize()
 
-                ee.ImageCollection('NASA/GPM_L3/IMERG_V06').getDOI()
+                ee.ImageCollection('NASA/GPM_L3/IMERG_V06').geetools.getDOI()
         """
         return ee_extra.STAC.core.getDOI(self._obj)
 
@@ -338,6 +363,9 @@ class ImageCollectionAccessor:
         Returns:
             Citation of the ee.Image dataset.
 
+        See Also:
+            - :docstring:`ee.ImageCollection.geetools.getDOI`
+
         Examples:
             .. jupyter-execute::
 
@@ -346,7 +374,7 @@ class ImageCollectionAccessor:
 
                 ee.Initialize()
 
-                ee.ImageCollection('NASA/GPM_L3/IMERG_V06').getCitation()
+                ee.ImageCollection('NASA/GPM_L3/IMERG_V06').geetools.getCitation()
         """
         return ee_extra.STAC.core.getCitation(self._obj)
 
@@ -380,27 +408,53 @@ class ImageCollectionAccessor:
         )
 
     def tasseledCap(self) -> ee.ImageCollection:
-        """Calculates tasseled cap brightness, wetness, and greenness components.
+        """Calculates tasseled cap brightness, wetness, and greenness components for all images in the collection.
 
         Tasseled cap transformations are applied using coefficients published for these
         supported platforms:
 
-        * Sentinel-2 MSI Level 1C
-        * Landsat 9 OLI-2 SR
-        * Landsat 9 OLI-2 TOA
-        * Landsat 8 OLI SR
-        * Landsat 8 OLI TOA
-        * Landsat 7 ETM+ TOA
-        * Landsat 5 TM Raw DN
-        * Landsat 4 TM Raw DN
-        * Landsat 4 TM Surface Reflectance
-        * MODIS NBAR
+        * Sentinel-2 MSI Level 1C [1]_
+        * Landsat 9 OLI-2 SR [2]_
+        * Landsat 9 OLI-2 TOA [2]_
+        * Landsat 8 OLI SR [2]_
+        * Landsat 8 OLI TOA [2]_
+        * Landsat 7 ETM+ TOA [3]_
+        * Landsat 5 TM Raw DN [4]_
+        * Landsat 4 TM Raw DN [5]_
+        * Landsat 4 TM Surface Reflectance [6]_
+        * MODIS NBAR [7]_
 
         Parameters:
             self: ee.ImageCollection to calculate tasseled cap components for. Must belong to a supported platform.
 
         Returns:
             ImageCollections with the tasseled cap components as new bands.
+
+        References:
+            .. [1] Shi, T., & Xu, H. (2019). Derivation of Tasseled Cap Transformation
+                Coefficients for Sentinel-2 MSI At-Sensor Reflectance Data. IEEE Journal
+                of Selected Topics in Applied Earth Observations and Remote Sensing, 1-11.
+                doi:10.1109/jstars.2019.2938388
+            .. [2] Zhai, Y., Roy, D.P., Martins, V.S., Zhang, H.K., Yan, L., Li, Z. 2022.
+                Conterminous United States Landsat-8 top of atmosphere and surface reflectance
+                tasseled cap transformation coefficients. Remote Sensing of Environment,
+                274(2022). doi:10.1016/j.rse.2022.112992
+            .. [3] Huang, C., Wylie, B., Yang, L., Homer, C. and Zylstra, G., 2002.
+                Derivation of a tasselled cap transformation based on Landsat 7 at-satellite
+                reflectance. International journal of remote sensing, 23(8), pp.1741-1748.
+            .. [4] Crist, E.P., Laurin, R. and Cicone, R.C., 1986, September. Vegetation and
+                soils information contained in transformed Thematic Mapper data. In
+                Proceedings of IGARSS`86 symposium (pp. 1465-1470). Paris: European Space
+                Agency Publications Division.
+            .. [5] Crist, E.P. and Cicone, R.C., 1984. A physically-based transformation of
+                Thematic Mapper data---The TM Tasseled Cap. IEEE Transactions on Geoscience
+                and Remote sensing, (3), pp.256-263.
+            .. [6] Crist, E.P., 1985. A TM tasseled cap equivalent transformation for
+                reflectance factor data. Remote sensing of Environment, 17(3), pp.301-306.
+            .. [7] Lobser, S.E. and Cohen, W.B., 2007. MODIS tasselled cap: land cover
+                characteristics expressed through transformed MODIS data. International
+                Journal of Remote Sensing, 28(22), pp.5079-5101.
+
 
         Examples:
             .. code-block:: python
@@ -409,8 +463,8 @@ class ImageCollectionAccessor:
 
                 ee.Initialize()
 
-                image = ee.Image('COPERNICUS/S2_SR')
-                img = img.tasseledCap()
+                ic = ee.ImageCollection("LANDSAT/LT05/C01/T1")
+                ic = ic.geetools.tasseledCap()
         """
         return ee_extra.Spectral.core.tasseledCap(self._obj)
 
@@ -436,7 +490,7 @@ class ImageCollectionAccessor:
                 ic2018 = ic.filterBounds(geom).filterDate('2019-07-01', '2019-10-01')
                 ic2021 = ic.filterBounds(geom).filterDate('2021-07-01', '2021-10-01')
 
-                ic = ic2018.append(ic2021.first())
+                ic = ic2018.geetools.append(ic2021.first())
                 ic.getInfo()
         """
         return self._obj.merge(ee.ImageCollection([image]))

--- a/geetools/ee_image_collection.py
+++ b/geetools/ee_image_collection.py
@@ -822,6 +822,7 @@ class ImageCollectionAccessor:
 
         return ee.ImageCollection(ic)
 
+    # TODO: Fix the example
     def containsAllBands(self, bandNames: list | ee.List) -> ee.ImageCollection:
         """Filter the ImageCollection keeping only the images with all the provided bands.
 
@@ -832,7 +833,7 @@ class ImageCollectionAccessor:
             A filtered ImageCollection
 
         Examples:
-            .. jupyter-execute::
+            .. code-block::
 
                 import ee, geetools
 

--- a/geetools/ee_image_collection.py
+++ b/geetools/ee_image_collection.py
@@ -68,7 +68,7 @@ class ImageCollectionAccessor:
             This method may mask water as well as clouds for the Sentinel-3 Radiance product.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -188,13 +188,13 @@ class ImageCollectionAccessor:
             Image with the computed spectral index, or indices, as new bands.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
                 ee.Initialize()
                 image = ee.Image('COPERNICUS/S2_SR/20190828T151811_20190828T151809_T18GYT')
-                image = image.geetools.specralIndices(["NDVI", "NDFI"])
+                image = image.geetools.spectralIndices(["NDVI", "NDFI"])
         """
         # fmt: off
         return ee_extra.Spectral.core.spectralIndices(
@@ -248,7 +248,7 @@ class ImageCollectionAccessor:
             Scaled image.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -268,7 +268,7 @@ class ImageCollectionAccessor:
             Pre-processed image.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee
                 import geetools
@@ -365,7 +365,7 @@ class ImageCollectionAccessor:
             The ImageCollections with all sharpenable bands sharpened to the panchromatic resolution and quality assessments run and set as properties.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee
                 import geetools
@@ -403,7 +403,7 @@ class ImageCollectionAccessor:
             ImageCollections with the tasseled cap components as new bands.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 

--- a/geetools/ee_image_collection.py
+++ b/geetools/ee_image_collection.py
@@ -116,6 +116,7 @@ class ImageCollectionAccessor:
                 import ee
                 import geetools
 
+                ee.Initialize()
                 s2 = ee.ImageCollection('COPERNICUS/S2_SR').geetools.closest('2020-10-15')
                 s2.size().getInfo()
         """

--- a/geetools/ee_image_collection.py
+++ b/geetools/ee_image_collection.py
@@ -181,7 +181,7 @@ class ImageCollectionAccessor:
             slope: Soil line slope, default = 1.0
             intercept: Soil line intercept, default = 0.0
             gamma: Weighting coefficient used for ARVI, default = 1.0
-            omega: Weighting coefficient  used for MBWI, default = 2.0
+            omega: Weighting coefficient used for MBWI, default = 2.0
             beta: Calibration parameter used for NDSIns, default = 0.05
             k: Slope parameter by soil used for NIRvH2, default = 0.0
             fdelta: Adjustment factor used for SEVI, default = 0.581
@@ -724,10 +724,10 @@ class ImageCollectionAccessor:
             decode_timedelta: If True, decode variables and coordinates with time units in {"days", "hours", "minutes", "seconds", "milliseconds", "microseconds"} into timedelta objects. If False, leave them encoded as numbers. If None (default), assume the same value of decode_time.
             use_cftime: Only relevant if encoded dates come from a standard calendar (e.g. "gregorian", "proleptic_gregorian", "standard", or not specified).  If None (default), attempt to decode times to ``np.datetime64[ns]`` objects; if this is not possible, decode times to ``cftime.datetime`` objects. If True, always decode times to ``cftime.datetime`` objects, regardless of whether or not they can be represented using ``np.datetime64[ns]`` objects.  If False, always decode times to ``np.datetime64[ns]`` objects; if this is not possible raise an error.
             concat_characters: Should character arrays be concatenated to strings, for example: ["h", "e", "l", "l", "o"] -> "hello"
-            decode_coords: bool or {"coordinates", "all"}, Controls which variables are set as coordinate variables: - "coordinates" or True: Set variables referred to in the ``'coordinates'`` attribute of the datasets or individual variables as coordinate variables. - "all": Set variables referred to in  ``'grid_mapping'``, ``'bounds'`` and other attributes as coordinate variables.
+            decode_coords: bool or {"coordinates", "all"}, Controls which variables are set as coordinate variables: - "coordinates" or True: Set variables referred to in the ``'coordinates'`` attribute of the datasets or individual variables as coordinate variables. - "all": Set variables referred to in ``'grid_mapping'``, ``'bounds'`` and other attributes as coordinate variables.
             crs: The coordinate reference system (a CRS code or WKT string). This defines the frame of reference to coalesce all variables upon opening. By default, data is opened with 'EPSG:4326'.
             scale: The scale in the ``crs`` or ``projection``'s units of measure -- either meters or degrees. This defines the scale that all data is represented in upon opening. By default, the scale is 1° when the CRS is in degrees or 10,000 when in meters.
-            projection: Specify an ``ee.Projection`` object to define the ``scale`` and ``crs`` (or other coordinate reference system) with which to coalesce all variables upon opening. By default, the scale and reference system is set by the the ``crs`` and ``scale`` arguments.
+            projection: Specify an ``ee.Projection`` object to define the ``scale`` and ``crs`` (or other coordinate reference system) with which to coalesce all variables upon opening. By default, the scale and reference system is set by the ``crs`` and ``scale`` arguments.
             geometry: Specify an ``ee.Geometry`` to define the regional bounds when opening the data. When not set, the bounds are defined by the CRS's ``area_of_use`` boundaries. If those aren't present, the bounds are derived from the geometry of the first image of the collection.
             primary_dim_name: Override the name of the primary dimension of the output Dataset. By default, the name is 'time'.
             primary_dim_property: Override the ``ee.Image`` property for which to derive the values of the primary dimension. By default, this is 'system:time_start'.
@@ -2338,14 +2338,14 @@ class ImageCollectionAccessor:
             }
 
         Warning:
-            The method makes a call to the pure Python ``uuid`` package so it cannot be used in a server-side ``map`` function.
+            The method makes a call to the pure Python ``uuid`` package, so it cannot be used in a server-side ``map`` function.
 
         Parameters:
             idProperty: The property to use as the key of the resulting dictionary. If not specified, the key of the dictionary is the index of the image in the collection. One should use a meaningful property to avoid conflicts. in case of conflicts, the images with the same property will be mosaicked together (e.g. all raw satellite imagery with the same date) to make sure the final reducer have 1 single entry per idProperty.
             reducer: THe reducer to apply.
             idType: The type of the idProperty. Default is ee.Number. As Dates are stored as numbers in metadata, we need to know what parsing to apply to the property in advance.
             idReducer: If the multiple images have the same idProperty, they will be aggregated beforehand using the provided reducer. default to a mosaic behaviour to match most of the satellite imagery collection where the world is split for each date between multiple images.
-            idFormat: If a date format is used for the IdProperty, the values will be formatted as "YYYY-MM-ddThh-mm-ss". If a number format is used for the IdProperty, the values will be formatted as a string  ("%s"). You can specify any other format compatible with band names.
+            idFormat: If a date format is used for the IdProperty, the values will be formatted as "YYYY-MM-ddThh-mm-ss". If a number format is used for the IdProperty, the values will be formatted as a string ("%s"). You can specify any other format compatible with band names.
             geometry: The region over which to reduce the data.
             scale: A nominal scale in meters to work in.
             crs: The projection to work in. If unspecified, the projection of the image's first band is used. If specified in addition to scale, rescaled to the specified scale.
@@ -2491,7 +2491,7 @@ class ImageCollectionAccessor:
             sentinel2_id_3,feature_2,feature2_prop1,feature2_prop2,...,reduced_image3_band1_feature2,reduced_image3_band2_feature2,...
 
         Warning:
-            The method makes a call to the pure Python uuid package so it cannot be used in a server-side map function.
+            The method makes a call to the pure Python uuid package, so it cannot be used in a server-side map function.
 
         Parameters:
             reducer: The reducer to apply.
@@ -2499,7 +2499,7 @@ class ImageCollectionAccessor:
             idProperty: The property to use as the key of the resulting dictionary. If not specified, the key of the dictionary is the index of the image in the collection. One should use a meaningful property to avoid conflicts. in case of conflicts, the images with the same property will be mosaicked together (e.g. all raw satellite imagery with the same date) to make sure the final reducer have 1 single entry per idProperty.
             idType: The type of the idProperty. Default is ee.Number. As Dates are stored as numbers in metadata, we need to know what parsing to apply to the property in advance.
             idReducer: If the multiple images have the same idProperty, they will be aggregated beforehand using the provided reducer. default to a mosaic behaviour to match most of the satellite imagery collection where the world is split for each date between multiple images.
-            idFormat: If a date format is used for the IdProperty, the values will be formatted as "YYYY-MM-ddThh-mm-ss". If a number format is used for the IdProperty, the values will be formatted as a string  ("%s"). You can specify any other format compatible with band names.
+            idFormat: If a date format is used for the IdProperty, the values will be formatted as "YYYY-MM-ddThh-mm-ss". If a number format is used for the IdProperty, the values will be formatted as a string ("%s"). You can specify any other format compatible with band names.
             scale: A nominal scale in meters to work in.
             crs: The projection to work in. If unspecified, the projection of the image's first band is used. If specified in addition to scale, rescaled to the specified scale.
             crsTransform: The list of CRS transform values. This is a row-major ordering of the 3x2 transform matrix. This option is mutually exclusive with 'scale', and replaces any transform already set on the projection.

--- a/geetools/ee_image_collection.py
+++ b/geetools/ee_image_collection.py
@@ -23,6 +23,9 @@ EE_DATE_FORMAT = "YYYY-MM-dd'T'HH-mm-ss"
 "The javascript format to use to burn date object in GEE."
 
 
+# TODO: Usually the image collection "LANDSAT/LC08/C01/T1_TOA" brings
+#  an error when trying to be imported. It is a future work to fix this
+#  issue.
 @register_class_accessor(ee.ImageCollection, "geetools")
 class ImageCollectionAccessor:
     """Toolbox for the ``ee.ImageCollection`` class."""
@@ -554,7 +557,7 @@ class ImageCollectionAccessor:
             An Image object with the integrated band for each pixel
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -639,7 +642,7 @@ class ImageCollectionAccessor:
             an ImageCollection with the outlier band added to each image or masked if ``drop`` is ``True``
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -759,7 +762,7 @@ class ImageCollectionAccessor:
             an Image with the number of valid pixels or the percentage of valid pixels.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
                 collection = (
@@ -788,7 +791,7 @@ class ImageCollectionAccessor:
             A filtered ImageCollection
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -822,7 +825,6 @@ class ImageCollectionAccessor:
 
         return ee.ImageCollection(ic)
 
-    # TODO: Fix the example
     def containsAllBands(self, bandNames: list | ee.List) -> ee.ImageCollection:
         """Filter the ImageCollection keeping only the images with all the provided bands.
 
@@ -860,7 +862,7 @@ class ImageCollectionAccessor:
             A filtered ImageCollection
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -887,7 +889,7 @@ class ImageCollectionAccessor:
             A dictionary with the properties as keys and the aggregated values as values.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -906,13 +908,12 @@ class ImageCollectionAccessor:
         values = keys.map(lambda p: self._obj.aggregate_array(p))
         return ee.Dictionary.fromLists(keys, values)
 
-    # TODO: Fix the example
     def groupInterval(self, unit: str = "month", duration: int = 1) -> ee.List:
         """Transform the ImageCollection into a list of smaller collection of the specified duration.
 
         For example using unit as "month" and duration as 1, the ImageCollection will be transformed
         into a list of ImageCollection with each ImageCollection containing images for each month.
-        Make sure the collection is filtered beforeend to reduce the number of images that needs to be
+        Make sure the collection is filtered beforehand to reduce the number of images that needs to be
         processed.
 
         Args:
@@ -920,7 +921,7 @@ class ImageCollectionAccessor:
             duration: The duration of each split.
 
         Returns:
-            A list of imagecollection grouped by interval
+            A list of ``ee.ImageCollection`` grouped by interval
 
         Examples:
             .. code-block:: python
@@ -974,10 +975,10 @@ class ImageCollectionAccessor:
             duration: The duration of each split.
 
         Returns:
-            A new ImageCollection with the reduced images.
+            A new ``ee.ImageCollection`` with the reduced images.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -1024,7 +1025,7 @@ class ImageCollectionAccessor:
             An ImageCollection with all pixels unmasked in every image.
 
         Examples:
-            .. code:: python
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -1061,7 +1062,7 @@ class ImageCollectionAccessor:
             An Image that is the medoid of the ImageCollection.
 
         Examples:
-            .. code:: python
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -1251,7 +1252,7 @@ class ImageCollectionAccessor:
             - :docstring:`ee.ImageCollection.geetools.plot_doy_by_regions`
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -1789,7 +1790,7 @@ class ImageCollectionAccessor:
             - :docstring:`ee.ImageCollection.geetools.plot_doy_by_years`
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -1874,7 +1875,7 @@ class ImageCollectionAccessor:
             - :docstring:`ee.ImageCollection.geetools.plot_doy_by_years`
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -1967,7 +1968,7 @@ class ImageCollectionAccessor:
             - :docstring:`ee.ImageCollection.geetools.plot_doy_by_years`
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -2055,7 +2056,7 @@ class ImageCollectionAccessor:
             - :docstring:`ee.ImageCollection.geetools.plot_doy_by_years`
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 

--- a/geetools/ee_image_collection.py
+++ b/geetools/ee_image_collection.py
@@ -24,9 +24,6 @@ EE_DATE_FORMAT = "YYYY-MM-dd'T'HH-mm-ss"
 "The javascript format to use to burn date object in GEE."
 
 
-# TODO: Usually the image collection "LANDSAT/LC08/C01/T1_TOA" brings
-#  an error when trying to be imported. It is a future work to fix this
-#  issue.
 @register_class_accessor(ee.ImageCollection, "geetools")
 class ImageCollectionAccessor:
     """Toolbox for the :py:class:`ee.ImageCollection` class."""
@@ -36,8 +33,6 @@ class ImageCollectionAccessor:
         self._obj = obj
 
     # -- ee-extra wrapper ------------------------------------------------------
-    # TODO: Currently (2024-12-20) there are a bug when you use this method with any S2.
-    #  This bug is related with ee-extra, so we have to wait until they fix the bug
     def maskClouds(
         self,
         method: str = "cloud_prob",
@@ -130,7 +125,6 @@ class ImageCollectionAccessor:
         """
         return ee_extra.ImageCollection.core.closest(self._obj, date, tolerance, unit)
 
-    # TODO: We can add the additional examples using https://eemont.readthedocs.io/en/latest/classes/stubs/eemont.imagecollection.spectralIndices.html
     def spectralIndices(
         self,
         index: str = "NDVI",
@@ -1146,7 +1140,6 @@ class ImageCollectionAccessor:
 
         return ee.Image(medoid).select(bandNames)
 
-    # TODO: Fix the example
     def datesByBands(
         self,
         region: ee.Geometry,

--- a/geetools/ee_image_collection.py
+++ b/geetools/ee_image_collection.py
@@ -822,7 +822,7 @@ class ImageCollectionAccessor:
         """
         return self.containsBandNames(bandNames, "ANY")
 
-    def aggregateArray(self, properties: list | ee.List | None = None) -> ee.Dict:
+    def aggregateArray(self, properties: list | ee.List | None = None) -> ee.Dictionary:
         """Aggregate the ImageCollection selected properties into a dictionary.
 
         Args:
@@ -995,7 +995,7 @@ class ImageCollectionAccessor:
 
         return ee.ImageCollection(imageList)
 
-    def medoid(self) -> ee.image:
+    def medoid(self) -> ee.Image:
         """Compute the medoid of the ImageCollection.
 
         The medoid is the image that has the smallest sum of distances to all other images in the collection.

--- a/geetools/ee_image_collection.py
+++ b/geetools/ee_image_collection.py
@@ -68,7 +68,7 @@ class ImageCollectionAccessor:
             This method may mask water as well as clouds for the Sentinel-3 Radiance product.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -107,7 +107,7 @@ class ImageCollectionAccessor:
             Closest images to the specified date.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee
                 import geetools
@@ -188,7 +188,7 @@ class ImageCollectionAccessor:
             Image with the computed spectral index, or indices, as new bands.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -212,7 +212,7 @@ class ImageCollectionAccessor:
 
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee
                 import geetools
@@ -230,7 +230,7 @@ class ImageCollectionAccessor:
             Dictionary with the offset parameters for each band.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
             import ee
             import geetools
@@ -248,7 +248,7 @@ class ImageCollectionAccessor:
             Scaled image.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -268,7 +268,7 @@ class ImageCollectionAccessor:
             Pre-processed image.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
             import ee
             import geetools
@@ -285,7 +285,7 @@ class ImageCollectionAccessor:
             STAC of the image.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
             import ee
             import geetools
@@ -321,7 +321,7 @@ class ImageCollectionAccessor:
             DOI of the ee.Image dataset.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee
                 import geetools
@@ -339,7 +339,7 @@ class ImageCollectionAccessor:
             Citation of the ee.Image dataset.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee
                 import geetools
@@ -365,7 +365,7 @@ class ImageCollectionAccessor:
             The ImageCollections with all sharpenable bands sharpened to the panchromatic resolution and quality assessments run and set as properties.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee
                 import geetools
@@ -403,7 +403,7 @@ class ImageCollectionAccessor:
             ImageCollections with the tasseled cap components as new bands.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -424,7 +424,7 @@ class ImageCollectionAccessor:
             ImageCollection with the new image appended.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -474,7 +474,7 @@ class ImageCollectionAccessor:
             ee.Image at the specified index.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -500,7 +500,7 @@ class ImageCollectionAccessor:
             An Image object with the integrated band for each pixel
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, LDCGEETools
 
@@ -585,7 +585,7 @@ class ImageCollectionAccessor:
             an ImageCollection with the outlier band added to each image or masked if ``drop`` is ``True``
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, LDCGEETools
 
@@ -705,7 +705,7 @@ class ImageCollectionAccessor:
             an Image with the number of valid pixels or the percentage of valid pixels.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
                 import ee, LDCGEETools
                 collection = (
                     ee.ImageCollection("LANDSAT/LC08/C01/T1_TOA")
@@ -733,7 +733,7 @@ class ImageCollectionAccessor:
             A filtered ImageCollection
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, LDCGEETools
 
@@ -777,7 +777,7 @@ class ImageCollectionAccessor:
             A filtered ImageCollection
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -804,7 +804,7 @@ class ImageCollectionAccessor:
             A filtered ImageCollection
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -831,7 +831,7 @@ class ImageCollectionAccessor:
             A dictionary with the properties as keys and the aggregated values as values.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -866,7 +866,7 @@ class ImageCollectionAccessor:
             A list of imagecollection grouped by interval
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -920,7 +920,7 @@ class ImageCollectionAccessor:
             A new ImageCollection with the reduced images.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -1105,7 +1105,7 @@ class ImageCollectionAccessor:
             - :docstring:`ee.ImageCollection.geetools.plot_doy_by_regions`
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -1194,7 +1194,7 @@ class ImageCollectionAccessor:
             - :docstring:`ee.ImageCollection.geetools.plot_doy_by_regions`
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
             import ee, geetools
 
@@ -1732,7 +1732,7 @@ class ImageCollectionAccessor:
             - :docstring:`ee.ImageCollection.geetools.plot_doy_by_years`
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -1817,7 +1817,7 @@ class ImageCollectionAccessor:
             - :docstring:`ee.ImageCollection.geetools.plot_doy_by_years`
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
             import ee, geetools
 
@@ -1910,7 +1910,7 @@ class ImageCollectionAccessor:
             - :docstring:`ee.ImageCollection.geetools.plot_doy_by_years`
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 
@@ -1998,7 +1998,7 @@ class ImageCollectionAccessor:
             - :docstring:`ee.ImageCollection.geetools.plot_doy_by_years`
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee, geetools
 

--- a/geetools/ee_image_collection.py
+++ b/geetools/ee_image_collection.py
@@ -906,6 +906,7 @@ class ImageCollectionAccessor:
         values = keys.map(lambda p: self._obj.aggregate_array(p))
         return ee.Dictionary.fromLists(keys, values)
 
+    # TODO: Fix the example
     def groupInterval(self, unit: str = "month", duration: int = 1) -> ee.List:
         """Transform the ImageCollection into a list of smaller collection of the specified duration.
 
@@ -922,7 +923,7 @@ class ImageCollectionAccessor:
             A list of imagecollection grouped by interval
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 

--- a/geetools/ee_image_collection.py
+++ b/geetools/ee_image_collection.py
@@ -511,7 +511,7 @@ class ImageCollectionAccessor:
         """A binary ee.Image where only pixels that are masked in all images of the collection get masked.
 
         Returns:
-            ee.Image of the mask. 1 where at least 1 pixel is valid 0 elswere
+            ee.Image of the mask. 1 where at least 1 pixel is valid 0 elsewhere
 
         Examples:
             .. code-block::
@@ -638,7 +638,7 @@ class ImageCollectionAccessor:
 
         Here in this function an extra band is added to each image for each of the evaluated bands with the outlier status. The band name is the original band name with the suffix "_outlier". A value of 1 means that the pixel is an outlier, 0 means that it is not.
 
-        Optionally users can discard this band by setting ``drop`` to ``True`` and the outlier will simply be masked from each ilmage. This is useful when the outlier band is not needed and the user wants to save space.
+        Optionally users can discard this band by setting ``drop`` to ``True`` and the outlier will simply be masked from each image. This is useful when the outlier band is not needed and the user wants to save space.
 
         idea from: https://www.kdnuggets.com/2017/02/removing-outliers-standard-deviation-python.html
 
@@ -1027,7 +1027,7 @@ class ImageCollectionAccessor:
         """Fill masked pixels with the first valid pixel in the stack of images.
 
         The method will for every image, fill all the pixels with the latest nono masked pixel in the stack of images.
-        I requires the image to have a valid "system:time_start" property.
+        It requires the image to have a valid "system:time_start" property.
         As the imageCollection will need to be sorted limit the analysis to a reasonable number of image by filtering your data beforehand.
 
         Returns:
@@ -2349,7 +2349,7 @@ class ImageCollectionAccessor:
             geometry: The region over which to reduce the data.
             scale: A nominal scale in meters to work in.
             crs: The projection to work in. If unspecified, the projection of the image's first band is used. If specified in addition to scale, rescaled to the specified scale.
-            crstransform: The list of CRS transform values. This is a row-major ordering of the 3x2 transform matrix. This option is mutually exclusive with 'scale', and replaces any transform already set on the projection.
+            crsTransform: The list of CRS transform values. This is a row-major ordering of the 3x2 transform matrix. This option is mutually exclusive with 'scale', and replaces any transform already set on the projection.
             bestEffort: If the polygon would contain too many pixels at the given scale, compute and use a larger scale which would allow the operation to succeed.
             maxPixels: The maximum number of pixels to reduce.
             tileScale: A scaling factor between 0.1 and 16 used to adjust aggregation tile size; setting a larger tileScale (e.g., 2 or 4) uses smaller tiles and may enable computations that run out of memory with the default.
@@ -2473,7 +2473,7 @@ class ImageCollectionAccessor:
     ) -> ee.FeatureCollection:
         """Apply a reducer to all the pixels in specific regions on each images of a collection.
 
-        The result will be shaped as a FeatureCollection with the idProperty as key and for each of them the reduced band values over one regions.
+        The result will be shaped as a FeatureCollection with the idProperty as key and for each of them the reduced band values over one region.
         Each feature will have the same properties as the original feature collection and thus be identified by a key pair:
         "system:id" + "system:image_property"
 
@@ -2502,7 +2502,7 @@ class ImageCollectionAccessor:
             idFormat: If a date format is used for the IdProperty, the values will be formatted as "YYYY-MM-ddThh-mm-ss". If a number format is used for the IdProperty, the values will be formatted as a string  ("%s"). You can specify any other format compatible with band names.
             scale: A nominal scale in meters to work in.
             crs: The projection to work in. If unspecified, the projection of the image's first band is used. If specified in addition to scale, rescaled to the specified scale.
-            crstransform: The list of CRS transform values. This is a row-major ordering of the 3x2 transform matrix. This option is mutually exclusive with 'scale', and replaces any transform already set on the projection.
+            crsTransform: The list of CRS transform values. This is a row-major ordering of the 3x2 transform matrix. This option is mutually exclusive with 'scale', and replaces any transform already set on the projection.
             tileScale: A scaling factor between 0.1 and 16 used to adjust aggregation tile size; setting a larger tileScale (e.g., 2 or 4) uses smaller tiles and may enable computations that run out of memory with the default.
 
         Returns:

--- a/geetools/ee_image_collection.py
+++ b/geetools/ee_image_collection.py
@@ -290,7 +290,7 @@ class ImageCollectionAccessor:
         """Pre-processes the image: masks clouds and shadows, and scales and offsets the image collection.
 
         Parameters:
-            **kwargs: Keywords arguments for `~.maskClouds` method.
+            **kwargs: Keywords arguments for :py:meth:`ee.ImageCollection.geetools.maskClouds <geetools.ee_image_collection.ImageCollectionAccessor.maskClouds>` method.
 
         Returns:
             Pre-processed image.
@@ -352,7 +352,7 @@ class ImageCollectionAccessor:
         """Gets the DOI of the collection, if available.
 
         Returns:
-            DOI of the ee.Image dataset.
+            DOI of the :py:class:`ee.Image` dataset.
 
         See Also:
             - :docstring:`ee.ImageCollection.geetools.getCitation`
@@ -373,7 +373,7 @@ class ImageCollectionAccessor:
         """Gets the citation of the image, if available.
 
         Returns:
-            Citation of the ee.Image dataset.
+            Citation of the :py:class:`ee.Image` dataset.
 
         See Also:
             - :docstring:`ee.ImageCollection.geetools.getDOI`
@@ -440,7 +440,7 @@ class ImageCollectionAccessor:
             self: :py:class:`ee.ImageCollection` to calculate tasseled cap components for. Must belong to a supported platform.
 
         Returns:
-            ImageCollections with the tasseled cap components as new bands.
+            Image Collections with the tasseled cap components as new bands.
 
         References:
             .. [1] Shi, T., & Xu, H. (2019). Derivation of Tasseled Cap Transformation
@@ -508,10 +508,10 @@ class ImageCollectionAccessor:
         return self._obj.merge(ee.ImageCollection([image]))
 
     def collectionMask(self) -> ee.Image:
-        """A binary ee.Image where only pixels that are masked in all images of the collection get masked.
+        """A binary :py:class:`ee.Image` where only pixels that are masked in all images of the collection get masked.
 
         Returns:
-            ee.Image of the mask. 1 where at least 1 pixel is valid 0 elsewhere
+            :py:class:`ee.Image` of the mask. 1 where at least 1 pixel is valid 0 elsewhere
 
         Examples:
             .. code-block::
@@ -537,7 +537,7 @@ class ImageCollectionAccessor:
             index: Index of the image to get.
 
         Returns:
-            :py:class`ee.Image` at the specified index.
+            :py:class:`ee.Image` at the specified index.
 
         Examples:
             .. code-block:: python
@@ -558,12 +558,12 @@ class ImageCollectionAccessor:
         """Compute the integral of a band over time or a specified property.
 
         Args:
-            band: the name of the band to integrate
+            band: the name of the band to integrate.
             time: the name of the property to use as time. It must be a date property of the images.
             unit: the time unit use to compute the integral. It can be one of the following: ``year``, ``month``, ``day``, ``hour``, ``minute``, ``second``. If non is set, the time will be normalized on the integral length.
 
         Returns:
-            An Image object with the integrated band for each pixel
+            An :py:class:`ee.Image` object with the integrated band for each pixel.
 
         Examples:
             .. code-block:: python
@@ -629,12 +629,12 @@ class ImageCollectionAccessor:
             outlier = value < mean-(sigma*stddev)
 
         In a 1D example it would be:
-        - values = [1, 5, 6, 4, 7, 10]
-        - mean = 5.5
-        - std dev = 3
-        - mean + (sigma*stddev) = 8.5
-        - mean - (sigma*stddev) = 2.5
-        - outliers = values between 2.5 and 8.5 = [1, 10]
+            - values = [1, 5, 6, 4, 7, 10]
+            - mean = 5.5
+            - std dev = 3
+            - mean + (sigma*stddev) = 8.5
+            - mean - (sigma*stddev) = 2.5
+            - outliers = values between 2.5 and 8.5 = [1, 10]
 
         Here in this function an extra band is added to each image for each of the evaluated bands with the outlier status. The band name is the original band name with the suffix "_outlier". A value of 1 means that the pixel is an outlier, 0 means that it is not.
 
@@ -643,12 +643,12 @@ class ImageCollectionAccessor:
         idea from: https://www.kdnuggets.com/2017/02/removing-outliers-standard-deviation-python.html
 
         Args:
-            bands: the bands to evaluate for outliers. If empty, all bands are evaluated
-            sigma: the number of standard deviations to use to compute the outlier
-            drop: whether to drop the outlier band from the images
+            bands: The bands to evaluate for outliers. If empty, all bands are evaluated.
+            sigma: The number of standard deviations to use to compute the outlier.
+            drop: Whether to drop the outlier band from the images.
 
         Returns:
-            an :py:class:`ee.ImageCollection` with the outlier band added to each image or masked if ``drop`` is ``True``
+            A :py:class:`ee.ImageCollection` with the outlier band added to each image or masked if ``drop`` is ``True``.
 
         Examples:
             .. code-block:: python
@@ -766,9 +766,10 @@ class ImageCollectionAccessor:
         one with the number of valid pixels (``valid``) and another with the percentage of valid pixels (``pct_valid``).
 
         Args:
-            band: the band to evaluate for valid pixels. If empty, use the first band
+            band: the band to evaluate for valid pixels. If empty, use the first band.
+
         Returns:
-            an Image with the number of valid pixels or the percentage of valid pixels.
+            An Image with the number of valid pixels or the percentage of valid pixels.
 
         Examples:
             .. code-block:: python
@@ -1027,7 +1028,7 @@ class ImageCollectionAccessor:
         """Fill masked pixels with the first valid pixel in the stack of images.
 
         The method will for every image, fill all the pixels with the latest nono masked pixel in the stack of images.
-        It requires the image to have a valid "system:time_start" property.
+        It requires the image to have a valid ``"system:time_start"`` property.
         As the imageCollection will need to be sorted limit the analysis to a reasonable number of image by filtering your data beforehand.
 
         Returns:
@@ -1068,7 +1069,7 @@ class ImageCollectionAccessor:
         The distance is computed using the Euclidean distance between the pixels of the images.
 
         Returns:
-            An Image that is the medoid of the :py:class:`ee.ImageCollection`
+            An Image that is the medoid of the :py:class:`ee.ImageCollection`.
 
         Examples:
             .. code-block:: python

--- a/geetools/ee_image_collection.py
+++ b/geetools/ee_image_collection.py
@@ -35,6 +35,8 @@ class ImageCollectionAccessor:
         self._obj = obj
 
     # -- ee-extra wrapper ------------------------------------------------------
+    # TODO: Currently (2024-12-20) there are a bug when you use this method with any S2.
+    #  This bug is related with ee-extra, so we have to wait until they fix the bug
     def maskClouds(
         self,
         method: str = "cloud_prob",
@@ -96,9 +98,6 @@ class ImageCollectionAccessor:
             cdi,
         )
 
-    # TODO: This method takes a lot of time, but it seems that is a problem of ee-extra.
-    #  By the way, I can't understad why. This is the source code:
-    #  https://github.com/r-earthengine/ee_extra/blob/master/ee_extra/ImageCollection/core.py
     def closest(
         self, date: ee.Date | str, tolerance: int = 1, unit: str = "month"
     ) -> ee.ImageCollection:
@@ -114,13 +113,18 @@ class ImageCollectionAccessor:
             Closest images to the specified date.
 
         Examples:
-            .. code-block:: python
+            .. jupyter-execute::
 
                 import ee
                 import geetools
 
                 ee.Initialize()
-                s2 = ee.ImageCollection('COPERNICUS/S2_SR').geetools.closest('2020-10-15')
+                geom = ee.Geometry.point(-122.196, 41.411)
+                s2 = (
+                    ee.ImageCollection('COPERNICUS/S2_SR_HARMONIZED')
+                    .filterBounds(geom)
+                    .geetools.closest('2020-10-15')
+                )
                 s2.size().getInfo()
         """
         return ee_extra.ImageCollection.core.closest(self._obj, date, tolerance, unit)
@@ -277,7 +281,7 @@ class ImageCollectionAccessor:
 
                 ee.Initialize()
 
-                S2 = ee.ImageCollection('COPERNICUS/S2_SR').scaleAndOffset()
+                S2 = ee.ImageCollection('COPERNICUS/S2_SR_HARMONIZED').scaleAndOffset()
         """
         return ee_extra.STAC.core.scaleAndOffset(self._obj)
 
@@ -303,7 +307,7 @@ class ImageCollectionAccessor:
                 import geetools
 
                 ee.Initialize()
-                S2 = ee.ImageCollection('COPERNICUS/S2_SR').preprocess()
+                S2 = ee.ImageCollection('COPERNICUS/S2_SR_HARMONIZED').preprocess()
         """
         return ee_extra.QA.pipelines.preprocess(self._obj, **kwargs)
 
@@ -321,7 +325,7 @@ class ImageCollectionAccessor:
 
                 ee.Initialize()
 
-                ee.ImageCollection('COPERNICUS/S2_SR').geetools.getSTAC()
+                ee.ImageCollection('COPERNICUS/S2_SR_HARMONIZED').geetools.getSTAC()
         """
         # extract the Asset id from the imagecollection
         assetId = self._obj.get("system:id").getInfo()
@@ -491,7 +495,7 @@ class ImageCollectionAccessor:
 
                 ee.Initialize()
 
-                ic = ee.ImageCollection('COPERNICUS/S2_SR');
+                ic = ee.ImageCollection('COPERNICUS/S2_SR_HARMONIZED');
 
                 geom = ee.Geometry.Point(-122.196, 41.411);
                 ic2018 = ic.filterBounds(geom).filterDate('2019-07-01', '2019-10-01')
@@ -515,7 +519,7 @@ class ImageCollectionAccessor:
 
                 ee.Initialize()
 
-                ic = ee.ImageCollection('COPERNICUS/S2_SR');
+                ic = ee.ImageCollection('COPERNICUS/S2_SR_HARMONIZED');
 
                 geom = ee.Geometry.Point(-122.196, 41.411);
                 ic2018 = ic.filterBounds(geom).filterDate('2019-07-01', '2019-10-01')
@@ -541,7 +545,7 @@ class ImageCollectionAccessor:
 
                 ee.Initialize()
 
-                ic = ee.ImageCollection('COPERNICUS/S2_SR');
+                ic = ee.ImageCollection('COPERNICUS/S2_SR_HARMONIZED');
 
                 geom = ee.Geometry.Point(-122.196, 41.411);
                 ic2018 = ic.filterBounds(geom).filterDate('2019-07-01', '2019-10-01')

--- a/geetools/ee_image_collection.py
+++ b/geetools/ee_image_collection.py
@@ -50,10 +50,10 @@ class ImageCollectionAccessor:
         buffer: int = 250,
         cdi: int | None = None,
     ) -> ee.ImageCollection:
-        """Masks clouds and shadows in each image of an ImageCollection (valid just for Surface Reflectance products).
+        """Masks clouds and shadows in each image of an ``ee.ImageCollection`` (valid just for Surface Reflectance products).
 
         Parameters:
-            self: ImageCollection to mask.
+            self: ``ee.ImageCollection`` to mask.
             method: Method used to mask clouds. This parameter is ignored for Landsat products.
                 Available options:
                     - 'cloud_prob' : Use cloud probability.
@@ -108,7 +108,7 @@ class ImageCollectionAccessor:
             self: Image Collection from which to get the closest image to the specified date.
             date: Date of interest. The method will look for images closest to this date.
             tolerance: Filter the collection to [date - tolerance, date + tolerance) before searching the closest image. This speeds up the searching process for collections with a high temporal resolution.
-            unit: Units for tolerance. Available units: 'year', 'month', 'week', 'day', 'hour', 'minute' or 'second'.
+            unit: Units for tolerance. Available units: ``'year'``, ``'month'``, ``'week'``, ``'day'``, ``'hour'``, ``'minute'`` or ``'second'``.
 
         Returns:
             Closest images to the specified date.
@@ -391,7 +391,7 @@ class ImageCollectionAccessor:
         return ee_extra.STAC.core.getCitation(self._obj)
 
     def panSharpen(self, method: str = "SFIM", qa: str = "", **kwargs) -> ee.ImageCollection:
-        """Apply panchromatic sharpening to the ImageCollection images.
+        """Apply panchromatic sharpening to the ``ee.ImageCollection`` images.
 
         Optionally, run quality assessments between the original and sharpened Image to
         measure spectral distortion and set results as properties of the sharpened Image.
@@ -437,7 +437,7 @@ class ImageCollectionAccessor:
         * MODIS NBAR [7]_
 
         Parameters:
-            self: ee.ImageCollection to calculate tasseled cap components for. Must belong to a supported platform.
+            self: ``ee.ImageCollection`` to calculate tasseled cap components for. Must belong to a supported platform.
 
         Returns:
             ImageCollections with the tasseled cap components as new bands.
@@ -487,7 +487,7 @@ class ImageCollectionAccessor:
             image: Image to append to the collection.
 
         Returns:
-            ImageCollection with the new image appended.
+            ``ee.ImageCollection`` with the new image appended.
 
         Examples:
             .. code-block:: python
@@ -531,7 +531,7 @@ class ImageCollectionAccessor:
         return ee.Image(masks.sum().gt(0))
 
     def iloc(self, index: int) -> ee.Image:
-        """Get Image from the ImageCollection by index.
+        """Get Image from the ``ee.ImageCollection`` by index.
 
         Args:
             index: Index of the image to get.
@@ -648,7 +648,7 @@ class ImageCollectionAccessor:
             drop: whether to drop the outlier band from the images
 
         Returns:
-            an ImageCollection with the outlier band added to each image or masked if ``drop`` is ``True``
+            an ``ee.ImageCollection`` with the outlier band added to each image or masked if ``drop`` is ``True``
 
         Examples:
             .. code-block:: python
@@ -713,7 +713,7 @@ class ImageCollectionAccessor:
         ee_mask_value: float | None = None,
         request_byte_limit: int = REQUEST_BYTE_LIMIT,
     ) -> Dataset:
-        """Open an Earth Engine ImageCollection as an ``xarray.Dataset``.
+        """Open an Earth Engine ``ee.ImageCollection`` as an ``xarray.Dataset``.
 
         Args:
             drop_variables: Variables or bands to drop before opening.
@@ -790,7 +790,7 @@ class ImageCollectionAccessor:
         return validPixel.addBands(validPct)
 
     def containsBandNames(self, bandNames: list | ee.List, filter: str) -> ee.ImageCollection:
-        """Filter the ImageCollection by band names using the provided filter.
+        """Filter the ``ee.ImageCollection`` by band names using the provided filter.
 
         Args:
             bandNames: list of band names to filter
@@ -835,7 +835,7 @@ class ImageCollectionAccessor:
         return ee.ImageCollection(ic)
 
     def containsAllBands(self, bandNames: list | ee.List) -> ee.ImageCollection:
-        """Filter the ImageCollection keeping only the images with all the provided bands.
+        """Filter the ``ee.ImageCollection`` keeping only the images with all the provided bands.
 
         Args:
             bandNames: list of band names to filter
@@ -862,7 +862,7 @@ class ImageCollectionAccessor:
         return self.containsBandNames(bandNames, "ALL")
 
     def containsAnyBands(self, bandNames: list | ee.List) -> ee.ImageCollection:
-        """Filter the ImageCollection keeping only the images with any of the provided bands.
+        """Filter the ``ee.ImageCollection`` keeping only the images with any of the provided bands.
 
         Args:
             bandNames: list of band names to filter
@@ -889,7 +889,7 @@ class ImageCollectionAccessor:
         return self.containsBandNames(bandNames, "ANY")
 
     def aggregateArray(self, properties: list | ee.List | None = None) -> ee.Dictionary:
-        """Aggregate the ImageCollection selected properties into a dictionary.
+        """Aggregate the ``ee.ImageCollection`` selected properties into a dictionary.
 
         Args:
             properties: list of properties to aggregate. If None, all properties are aggregated.
@@ -918,15 +918,15 @@ class ImageCollectionAccessor:
         return ee.Dictionary.fromLists(keys, values)
 
     def groupInterval(self, unit: str = "month", duration: int = 1) -> ee.List:
-        """Transform the ImageCollection into a list of smaller collection of the specified duration.
+        """Transform the ``ee.ImageCollection`` into a list of smaller collection of the specified duration.
 
-        For example using unit as "month" and duration as 1, the ImageCollection will be transformed
-        into a list of ImageCollection with each ImageCollection containing images for each month.
+        For example using unit as "month" and duration as 1, the ``ee.ImageCollection`` will be transformed
+        into a list of ``ee.ImageCollection`` with each ``ee.ImageCollection`` containing images for each month.
         Make sure the collection is filtered beforehand to reduce the number of images that needs to be
         processed.
 
         Args:
-            unit: The unit of time to split the collection. Available units: 'year', 'month', 'week', 'day', 'hour', 'minute' or 'second'.
+            unit: The unit of time to split the collection. Available units: ``'year'``, ``'month'``, ``'week'``, ``'day'``, ``'hour'``, ``'minute'`` or ``'second'``.
             duration: The duration of each split.
 
         Returns:
@@ -973,14 +973,14 @@ class ImageCollectionAccessor:
     ) -> ee.ImageCollection:
         """Reduce the images included in the same duration interval using the provided reducer.
 
-        For example using unit as "month" and duration as 1, the ImageCollection will be reduced
-        into a new ImageCollection with each image containing the reduced values for each month.
+        For example using unit as "month" and duration as 1, the ``ee.ImageCollection`` will be reduced
+        into a new ``ee.ImageCollection`` with each image containing the reduced values for each month.
         Make sure the collection is filtered beforehand to reduce the number of images that needs to be
         processed.
 
         Args:
-            reducer: The name of the reducer to use or a Reducer object. Default is "mean".
-            unit: The unit of time to split the collection. Available units: 'year', 'month', 'week', 'day', 'hour', 'minute' or 'second'.
+            reducer: The name of the reducer to use or a Reducer object. Default is ``"mean"``.
+            unit: The unit of time to split the collection. Available units: ``'year'``, ``'month'``, ``'week'``, ``'day'``, ``'hour'``, ``'minute'`` or ``'second'``.
             duration: The duration of each split.
 
         Returns:
@@ -1031,7 +1031,7 @@ class ImageCollectionAccessor:
         As the imageCollection will need to be sorted limit the analysis to a reasonable number of image by filtering your data beforehand.
 
         Returns:
-            An ImageCollection with all pixels unmasked in every image.
+            An ``ee.ImageCollection`` with all pixels unmasked in every image.
 
         Examples:
             .. code-block:: python
@@ -1153,8 +1153,8 @@ class ImageCollectionAccessor:
 
         Parameters:
             region: The region to reduce the data on.
-            reducer: The name of the reducer or a reducer object use. Default is "mean".
-            dateProperty: The property to use as date for each image. Default is "system:time_start".
+            reducer: The name of the reducer or a reducer object use. Default is ``"mean"``.
+            dateProperty: The property to use as date for each image. Default is ``"system:time_start"``.
             bands: The bands to reduce. If empty, all bands are reduced.
             labels: The labels to use for the bands. If empty, the bands names are used.
             scale: The scale in meters to use for the reduction. default is 10000m
@@ -1245,9 +1245,9 @@ class ImageCollectionAccessor:
         Parameters:
             band: The band to reduce.
             regions: The regions to reduce the data on.
-            label: The property to use as label for each region. Default is "system:index".
-            reducer: The name of the reducer or a reducer object use. Default is "mean".
-            dateProperty: The property to use as date for each image. Default is "system:time_start".
+            label: The property to use as label for each region. Default is ``"system:index"``.
+            reducer: The name of the reducer or a reducer object use. Default is ``"mean"``.
+            dateProperty: The property to use as date for each image. Default is ``"system:time_start"``.
             scale: The scale in meters to use for the reduction. default is 10000m
             crs: The projection to work in. If unspecified, the projection of the image's first band is used. If specified in addition to scale, rescaled to the specified scale.
             crsTransform: The list of CRS transform values. This is a row-major ordering of the 3x2 transform matrix. This option is mutually exclusive with 'scale', and replaces any transform already set on the projection.
@@ -1335,9 +1335,9 @@ class ImageCollectionAccessor:
 
         Parameters:
             region: The region to reduce the data on.
-            spatialReducer: The name of the reducer or a reducer object to use for spatial reduction. Default is "mean".
-            timeReducer: The name of the reducer or a reducer object to use for time reduction. Default is "mean".
-            dateProperty: The property to use as date for each image. Default is "system:time_start".
+            spatialReducer: The name of the reducer or a reducer object to use for spatial reduction. Default is ``"mean"``.
+            timeReducer: The name of the reducer or a reducer object to use for time reduction. Default is ``"mean"``.
+            dateProperty: The property to use as date for each image. Default is ``"system:time_start"``.
             bands: The bands to reduce. If empty, all bands are reduced.
             labels: The labels to use for the bands. If empty, the bands names are used.
             scale: The scale in meters to use for the reduction. default is 10000m
@@ -1451,10 +1451,10 @@ class ImageCollectionAccessor:
         Parameters:
             band: The band to reduce.
             regions: The regions to reduce the data on.
-            label: The property to use as label for each region. Default is "system:index".
-            spatialReducer: The name of the reducer or a reducer object to use for spatial reduction. Default is "mean".
-            timeReducer: The name of the reducer or a reducer object to use for time reduction. Default is "mean".
-            dateProperty: The property to use as date for each image. Default is "system:time_start".
+            label: The property to use as label for each region. Default is ``"system:index"``.
+            spatialReducer: The name of the reducer or a reducer object to use for spatial reduction. Default is ``"mean"``.
+            timeReducer: The name of the reducer or a reducer object to use for time reduction. Default is ``"mean"``.
+            dateProperty: The property to use as date for each image. Default is ``"system:time_start"``.
             scale: The scale in meters to use for the reduction. default is 10000m
             crs: The projection to work in. If unspecified, the projection of the image's first band is used. If specified in addition to scale, rescaled to the specified scale.
             crsTransform: The list of CRS transform values. This is a row-major ordering of the 3x2 transform matrix. This option is mutually exclusive with 'scale', and replaces any transform already set on the projection.
@@ -1547,7 +1547,7 @@ class ImageCollectionAccessor:
         """Aggregate for each year on a single region a single band.
 
         This method is returning a dictionary with all the years as keys and their reduced value for each day of the season over the specified region for a specific band as value.
-        To set the start and end of the season, use the :py:method:`ee.Date.getRelative` or :py:class:`time.struct_time` method to get the day of the year.
+        To set the start and end of the season, use the :py:meth:`ee.Date.getRelative` or :py:class:`time.struct_time` method to get the day of the year.
 
         .. code-block::
 
@@ -1562,8 +1562,8 @@ class ImageCollectionAccessor:
             region: The region to reduce the data on.
             seasonStart: The day of the year that marks the start of the season.
             seasonEnd: The day of the year that marks the end of the season.
-            reducer: The name of the reducer or a reducer object to use. Default is "mean".
-            dateProperty: The property to use as date for each image. Default is "system:time_start".
+            reducer: The name of the reducer or a reducer object to use. Default is ``"mean"``.
+            dateProperty: The property to use as date for each image. Default is ``"system:time_start"``.
             scale: The scale in meters to use for the reduction. default is 10000m
             crs: The projection to work in. If unspecified, the projection of the image's first band is used. If specified in addition to scale, rescaled to the specified scale.
             crsTransform: The list of CRS transform values. This is a row-major ordering of the 3x2 transform matrix. This option is mutually exclusive with 'scale', and replaces any transform already set on the projection.
@@ -1684,8 +1684,8 @@ class ImageCollectionAccessor:
         Parameters:
             band: The band to reduce.
             region: The region to reduce the data on.
-            reducer: The name of the reducer or a reducer object to use. Default is "mean".
-            dateProperty: The property to use as date for each image. Default is "system:time_start".
+            reducer: The name of the reducer or a reducer object to use. Default is ``"mean"``.
+            dateProperty: The property to use as date for each image. Default is ``"system:time_start"``.
             scale: The scale in meters to use for the reduction. default is 10000m
             crs: The projection to work in. If unspecified, the projection of the image's first band is used. If specified in addition to scale, rescaled to the specified scale.
             crsTransform: The list of CRS transform values. This is a row-major ordering of the 3x2 transform matrix. This option is mutually exclusive with 'scale', and replaces any transform already set on the projection.
@@ -1773,8 +1773,8 @@ class ImageCollectionAccessor:
 
         Parameters:
             region: The region to reduce the data on.
-            reducer: The name of the reducer or a reducer object to use. Default is "mean".
-            dateProperty: The property to use as date for each image. Default is "system:time_start".
+            reducer: The name of the reducer or a reducer object to use. Default is ``"mean"``.
+            dateProperty: The property to use as date for each image. Default is ``"system:time_start"``.
             bands: The bands to reduce. If empty, all bands are reduced.
             labels: The labels to use for the bands. If empty, the bands names are used.
             colors: The colors to use for the bands. If empty, the default colors are used.
@@ -1862,9 +1862,9 @@ class ImageCollectionAccessor:
         Parameters:
             band: The band to reduce.
             regions: The regions to reduce the data on.
-            label: The property to use as label for each region. Default is "system:index".
-            reducer: The name of the reducer or a reducer object to use. Default is "mean".
-            dateProperty: The property to use as date for each image. Default is "system:time_start".
+            label: The property to use as label for each region. Default is ``"system:index"``.
+            reducer: The name of the reducer or a reducer object to use. Default is ``"mean"``.
+            dateProperty: The property to use as date for each image. Default is ``"system:time_start"``.
             colors: The colors to use for the regions. If empty, the default colors are used.
             ax: The matplotlib axes to plot the data on. If None, a new figure is created.
             scale: The scale in meters to use for the reduction. default is 10000m
@@ -1951,9 +1951,9 @@ class ImageCollectionAccessor:
 
         Parameters:
             region: The region to reduce the data on.
-            spatialReducer: The name of the reducer or a reducer object to use. Default is "mean".
-            timeReducer: The name of the reducer or a reducer object to use. Default is "mean".
-            dateProperty: The property to use as date for each image. Default is "system:time_start".
+            spatialReducer: The name of the reducer or a reducer object to use. Default is ``"mean"``.
+            timeReducer: The name of the reducer or a reducer object to use. Default is ``"mean"``.
+            dateProperty: The property to use as date for each image. Default is ``"system:time_start"``.
             bands: The bands to reduce. If empty, all bands are reduced.
             labels: The labels to use for the bands. If empty, the bands names are used.
             colors: The colors to use for the bands. If empty, the default colors are used.
@@ -2042,10 +2042,10 @@ class ImageCollectionAccessor:
         Parameters:
             band: The band to reduce.
             regions: The regions to reduce the data on.
-            label: The property to use as label for each region. Default is "system:index".
-            spatialReducer: The name of the reducer or a reducer object to use. Default is "mean".
-            timeReducer: The name of the reducer or a reducer object to use. Default is "mean".
-            dateProperty: The property to use as date for each image. Default is "system:time_start".
+            label: The property to use as label for each region. Default is ``"system:index"``.
+            spatialReducer: The name of the reducer or a reducer object to use. Default is ``"mean"``.
+            timeReducer: The name of the reducer or a reducer object to use. Default is ``"mean"``.
+            dateProperty: The property to use as date for each image. Default is ``"system:time_start"``.
             colors: The colors to use for the regions. If empty, the default colors are used.
             ax: The matplotlib axes to plot the data on. If None, a new figure is created.
             scale: The scale in meters to use for the reduction. default is 10000m
@@ -2137,8 +2137,8 @@ class ImageCollectionAccessor:
             region: The region to reduce the data on.
             seasonStart: The day of the year that marks the start of the season.
             seasonEnd: The day of the year that marks the end of the season.
-            reducer: The name of the reducer or a reducer object to use. Default is "mean".
-            dateProperty: The property to use as date for each image. Default is "system:time_start".
+            reducer: The name of the reducer or a reducer object to use. Default is ``"mean"``.
+            dateProperty: The property to use as date for each image. Default is ``"system:time_start"``.
             colors: The colors to use for the regions. If empty, the default colors are used.
             ax: The matplotlib axes to plot the data on. If None, a new figure is created.
             scale: The scale in meters to use for the reduction. default is 10000m
@@ -2241,8 +2241,8 @@ class ImageCollectionAccessor:
         Parameters:
             band: The band to reduce.
             region: The region to reduce the data on.
-            reducer: The name of the reducer or a reducer object to use. Default is "mean".
-            dateProperty: The property to use as date for each image. Default is "system:time_start".
+            reducer: The name of the reducer or a reducer object to use. Default is ``"mean"``.
+            dateProperty: The property to use as date for each image. Default is ``"system:time_start"``.
             colors: The colors to use for the regions. If empty, the default colors are used.
             ax: The matplotlib axes to plot the data on. If None, a new figure is created.
             scale: The scale in meters to use for the reduction. default is 10000m

--- a/geetools/ee_image_collection.py
+++ b/geetools/ee_image_collection.py
@@ -232,12 +232,12 @@ class ImageCollectionAccessor:
         Examples:
             .. jupyter-execute::
 
-            import ee
-            import geetools
+                import ee
+                import geetools
 
-            ee.Initialize()
+                ee.Initialize()
 
-            ee.ImageCollection('MODIS/006/MOD11A2').getOffsetParams()
+                ee.ImageCollection('MODIS/006/MOD11A2').getOffsetParams()
         """
         return ee_extra.STAC.core.getOffsetParams(self._obj)
 
@@ -270,11 +270,11 @@ class ImageCollectionAccessor:
         Examples:
             .. jupyter-execute::
 
-            import ee
-            import geetools
+                import ee
+                import geetools
 
-            ee.Initialize()
-            S2 = ee.ImageCollection('COPERNICUS/S2_SR').preprocess()
+                ee.Initialize()
+                S2 = ee.ImageCollection('COPERNICUS/S2_SR').preprocess()
         """
         return ee_extra.QA.pipelines.preprocess(self._obj, **kwargs)
 
@@ -287,12 +287,12 @@ class ImageCollectionAccessor:
         Examples:
             .. jupyter-execute::
 
-            import ee
-            import geetools
+                import ee
+                import geetools
 
-            ee.Initialize()
+                ee.Initialize()
 
-            ee.ImageCollection('COPERNICUS/S2_SR').getSTAC()
+                ee.ImageCollection('COPERNICUS/S2_SR').getSTAC()
         """
         # extract the Asset id from the imagecollection
         assetId = self._obj.get("system:id").getInfo()
@@ -706,6 +706,7 @@ class ImageCollectionAccessor:
 
         Examples:
             .. jupyter-execute::
+
                 import ee, LDCGEETools
                 collection = (
                     ee.ImageCollection("LANDSAT/LC08/C01/T1_TOA")
@@ -1196,23 +1197,23 @@ class ImageCollectionAccessor:
         Examples:
             .. jupyter-execute::
 
-            import ee, geetools
+                import ee, geetools
 
-            ee.Initialize()
+                ee.Initialize()
 
-            collection = (
-                ee.ImageCollection("LANDSAT/LC08/C01/T1_TOA")
-                .filterBounds(ee.Geometry.Point(-122.262, 37.8719))
-                .filterDate("2014-01-01", "2014-12-31")
-            )
+                collection = (
+                    ee.ImageCollection("LANDSAT/LC08/C01/T1_TOA")
+                    .filterBounds(ee.Geometry.Point(-122.262, 37.8719))
+                    .filterDate("2014-01-01", "2014-12-31")
+                )
 
-            regions = ee.FeatureCollection([
-                ee.Feature(ee.Geometry.Point(-122.262, 37.8719).buffer(10000), {"name": "region1"}),
-                ee.Feature(ee.Geometry.Point(-122.262, 37.8719).buffer(20000), {"name": "region2"})
-            ])
+                regions = ee.FeatureCollection([
+                    ee.Feature(ee.Geometry.Point(-122.262, 37.8719).buffer(10000), {"name": "region1"}),
+                    ee.Feature(ee.Geometry.Point(-122.262, 37.8719).buffer(20000), {"name": "region2"})
+                ])
 
-            reduced = collection.geetools.datesByRegions("B1", regions, "name", "mean", 10000, "system:time_start")
-            print(reduced.getInfo())
+                reduced = collection.geetools.datesByRegions("B1", regions, "name", "mean", 10000, "system:time_start")
+                print(reduced.getInfo())
         """
         # aggregate all the dates of the image collection into bands of a single image
         def to_string(date: ee.Date) -> ee.String:
@@ -1819,22 +1820,22 @@ class ImageCollectionAccessor:
         Examples:
             .. jupyter-execute::
 
-            import ee, geetools
+                import ee, geetools
 
-            ee.Initialize()
+                ee.Initialize()
 
-            collection = (
-                ee.ImageCollection("LANDSAT/LC08/C01/T1_TOA")
-                .filterBounds(ee.Geometry.Point(-122.262, 37.8719))
-                .filterDate("2014-01-01", "2014-12-31")
-            )
+                collection = (
+                    ee.ImageCollection("LANDSAT/LC08/C01/T1_TOA")
+                    .filterBounds(ee.Geometry.Point(-122.262, 37.8719))
+                    .filterDate("2014-01-01", "2014-12-31")
+                )
 
-            regions = ee.FeatureCollection([
-                ee.Feature(ee.Geometry.Point(-122.262, 37.8719).buffer(10000), {"name": "region1"}),
-                ee.Feature(ee.Geometry.Point(-122.262, 37.8719).buffer(20000), {"name": "region2"})
-            ])
+                regions = ee.FeatureCollection([
+                    ee.Feature(ee.Geometry.Point(-122.262, 37.8719).buffer(10000), {"name": "region1"}),
+                    ee.Feature(ee.Geometry.Point(-122.262, 37.8719).buffer(20000), {"name": "region2"})
+                ])
 
-            collection.geetools.plot_dates_by_regions("B1", regions, "name", "mean", 10000, "system:time_start")
+                collection.geetools.plot_dates_by_regions("B1", regions, "name", "mean", 10000, "system:time_start")
         """
         # get the reduced data
         raw_data = self.datesByRegions(

--- a/geetools/ee_image_collection.py
+++ b/geetools/ee_image_collection.py
@@ -1,9 +1,9 @@
-"""Toolbox for the ``ee.ImageCollection`` class."""
+"""Toolbox for the :py:class:`ee.ImageCollection` class."""
 from __future__ import annotations
 
 import uuid
 from datetime import datetime as dt
-from typing import Any
+from typing import Any, Iterable
 
 import ee
 import ee_extra
@@ -29,7 +29,7 @@ EE_DATE_FORMAT = "YYYY-MM-dd'T'HH-mm-ss"
 #  issue.
 @register_class_accessor(ee.ImageCollection, "geetools")
 class ImageCollectionAccessor:
-    """Toolbox for the ``ee.ImageCollection`` class."""
+    """Toolbox for the :py:class:`ee.ImageCollection` class."""
 
     def __init__(self, obj: ee.ImageCollection):
         """Instantiate the class."""
@@ -50,10 +50,10 @@ class ImageCollectionAccessor:
         buffer: int = 250,
         cdi: int | None = None,
     ) -> ee.ImageCollection:
-        """Masks clouds and shadows in each image of an ``ee.ImageCollection`` (valid just for Surface Reflectance products).
+        """Masks clouds and shadows in each image of an :py:class:`ee.ImageCollection` (valid just for Surface Reflectance products).
 
         Parameters:
-            self: ``ee.ImageCollection`` to mask.
+            self: :py:class:`ee.ImageCollection` to mask.
             method: Method used to mask clouds. This parameter is ignored for Landsat products.
                 Available options:
                     - 'cloud_prob' : Use cloud probability.
@@ -105,10 +105,10 @@ class ImageCollectionAccessor:
         """Gets the closest image (or set of images if the collection intersects a region that requires multiple scenes) to the specified date.
 
         Parameters:
-            self: Image Collection from which to get the closest image to the specified date.
+            self: :py:class:`ee.ImageCollection` from which to get the closest image to the specified date.
             date: Date of interest. The method will look for images closest to this date.
             tolerance: Filter the collection to [date - tolerance, date + tolerance) before searching the closest image. This speeds up the searching process for collections with a high temporal resolution.
-            unit: Units for tolerance. Available units: ``'year'``, ``'month'``, ``'week'``, ``'day'``, ``'hour'``, ``'minute'`` or ``'second'``.
+            unit: Units for tolerance. Available units: ``year``, ``month``, ``week``, ``day``, ``hour``, ``minute`` or ``second``.
 
         Returns:
             Closest images to the specified date.
@@ -290,7 +290,7 @@ class ImageCollectionAccessor:
         """Pre-processes the image: masks clouds and shadows, and scales and offsets the image collection.
 
         Parameters:
-            **kwargs: Keywords arguments for ``maskClouds`` method.
+            **kwargs: Keywords arguments for `~.maskClouds` method.
 
         Returns:
             Pre-processed image.
@@ -391,7 +391,7 @@ class ImageCollectionAccessor:
         return ee_extra.STAC.core.getCitation(self._obj)
 
     def panSharpen(self, method: str = "SFIM", qa: str = "", **kwargs) -> ee.ImageCollection:
-        """Apply panchromatic sharpening to the ``ee.ImageCollection`` images.
+        """Apply panchromatic sharpening to the :py:class:`ee.ImageCollection` images.
 
         Optionally, run quality assessments between the original and sharpened Image to
         measure spectral distortion and set results as properties of the sharpened Image.
@@ -437,7 +437,7 @@ class ImageCollectionAccessor:
         * MODIS NBAR [7]_
 
         Parameters:
-            self: ``ee.ImageCollection`` to calculate tasseled cap components for. Must belong to a supported platform.
+            self: :py:class:`ee.ImageCollection` to calculate tasseled cap components for. Must belong to a supported platform.
 
         Returns:
             ImageCollections with the tasseled cap components as new bands.
@@ -487,7 +487,7 @@ class ImageCollectionAccessor:
             image: Image to append to the collection.
 
         Returns:
-            ``ee.ImageCollection`` with the new image appended.
+            :py:class:`ee.ImageCollection` with the new image appended.
 
         Examples:
             .. code-block:: python
@@ -531,13 +531,13 @@ class ImageCollectionAccessor:
         return ee.Image(masks.sum().gt(0))
 
     def iloc(self, index: int) -> ee.Image:
-        """Get Image from the ``ee.ImageCollection`` by index.
+        """Get Image from the :py:class:`ee.ImageCollection` by index.
 
         Args:
             index: Index of the image to get.
 
         Returns:
-            ee.Image at the specified index.
+            :py:class`ee.Image` at the specified index.
 
         Examples:
             .. code-block:: python
@@ -560,7 +560,7 @@ class ImageCollectionAccessor:
         Args:
             band: the name of the band to integrate
             time: the name of the property to use as time. It must be a date property of the images.
-            unit: the time unit use to compute the integral. It can be one of the following: ["year", "month", "day", "hour", "minute", "second"]. If non is set, the time will be normalized on the integral length.
+            unit: the time unit use to compute the integral. It can be one of the following: ``year``, ``month``, ``day``, ``hour``, ``minute``, ``second``. If non is set, the time will be normalized on the integral length.
 
         Returns:
             An Image object with the integrated band for each pixel
@@ -648,7 +648,7 @@ class ImageCollectionAccessor:
             drop: whether to drop the outlier band from the images
 
         Returns:
-            an ``ee.ImageCollection`` with the outlier band added to each image or masked if ``drop`` is ``True``
+            an :py:class:`ee.ImageCollection` with the outlier band added to each image or masked if ``drop`` is ``True``
 
         Examples:
             .. code-block:: python
@@ -695,7 +695,7 @@ class ImageCollectionAccessor:
 
     def to_xarray(
         self,
-        drop_variables: tuple[str, ...] | None = None,
+        drop_variables: str | Iterable[str] | None = None,
         io_chunks: object = None,
         n_images: int = -1,
         mask_and_scale: bool = True,
@@ -713,7 +713,7 @@ class ImageCollectionAccessor:
         ee_mask_value: float | None = None,
         request_byte_limit: int = REQUEST_BYTE_LIMIT,
     ) -> Dataset:
-        """Open an Earth Engine ``ee.ImageCollection`` as an ``xarray.Dataset``.
+        """Open an Earth Engine :py:class:`ee.ImageCollection` as an ``xarray.Dataset``.
 
         Args:
             drop_variables: Variables or bands to drop before opening.
@@ -790,14 +790,14 @@ class ImageCollectionAccessor:
         return validPixel.addBands(validPct)
 
     def containsBandNames(self, bandNames: list | ee.List, filter: str) -> ee.ImageCollection:
-        """Filter the ``ee.ImageCollection`` by band names using the provided filter.
+        """Filter the :py:class:`ee.ImageCollection` by band names using the provided filter.
 
         Args:
             bandNames: list of band names to filter
-            filter: type of filter to apply. To keep images that contains all the specified bands use "ALL". To get the images including at least one of the specified band use "ANY".
+            filter: type of filter to apply. To keep images that contains all the specified bands use ``"ALL"``. To get the images including at least one of the specified band use ``"ANY"``.
 
         Returns:
-            A filtered ImageCollection
+            A filtered :py:class:`ee.ImageCollection`
 
         Examples:
             .. code-block:: python
@@ -835,13 +835,13 @@ class ImageCollectionAccessor:
         return ee.ImageCollection(ic)
 
     def containsAllBands(self, bandNames: list | ee.List) -> ee.ImageCollection:
-        """Filter the ``ee.ImageCollection`` keeping only the images with all the provided bands.
+        """Filter the :py:class:`ee.ImageCollection` keeping only the images with all the provided bands.
 
         Args:
             bandNames: list of band names to filter
 
         Returns:
-            A filtered ImageCollection
+            A filtered :py:class:`ee.ImageCollection`
 
         Examples:
             .. code-block::
@@ -862,13 +862,13 @@ class ImageCollectionAccessor:
         return self.containsBandNames(bandNames, "ALL")
 
     def containsAnyBands(self, bandNames: list | ee.List) -> ee.ImageCollection:
-        """Filter the ``ee.ImageCollection`` keeping only the images with any of the provided bands.
+        """Filter the :py:class:`ee.ImageCollection` keeping only the images with any of the provided bands.
 
         Args:
             bandNames: list of band names to filter
 
         Returns:
-            A filtered ImageCollection
+            A filtered :py:class:`ee.ImageCollection`
 
         Examples:
             .. code-block:: python
@@ -889,7 +889,7 @@ class ImageCollectionAccessor:
         return self.containsBandNames(bandNames, "ANY")
 
     def aggregateArray(self, properties: list | ee.List | None = None) -> ee.Dictionary:
-        """Aggregate the ``ee.ImageCollection`` selected properties into a dictionary.
+        """Aggregate the :py:class:`ee.ImageCollection` selected properties into a dictionary.
 
         Args:
             properties: list of properties to aggregate. If None, all properties are aggregated.
@@ -918,19 +918,19 @@ class ImageCollectionAccessor:
         return ee.Dictionary.fromLists(keys, values)
 
     def groupInterval(self, unit: str = "month", duration: int = 1) -> ee.List:
-        """Transform the ``ee.ImageCollection`` into a list of smaller collection of the specified duration.
+        """Transform the :py:class:`ee.ImageCollection` into a list of smaller collection of the specified duration.
 
-        For example using unit as "month" and duration as 1, the ``ee.ImageCollection`` will be transformed
-        into a list of ``ee.ImageCollection`` with each ``ee.ImageCollection`` containing images for each month.
+        For example using unit as "month" and duration as 1, the :py:class:`ee.ImageCollection` will be transformed
+        into a list of :py:class:`ee.ImageCollection` with each :py:class:`ee.ImageCollection` containing images for each month.
         Make sure the collection is filtered beforehand to reduce the number of images that needs to be
         processed.
 
         Args:
-            unit: The unit of time to split the collection. Available units: ``'year'``, ``'month'``, ``'week'``, ``'day'``, ``'hour'``, ``'minute'`` or ``'second'``.
+            unit: The unit of time to split the collection. Available units: ``year``, ``month``, ``week``, ``day``, ``hour``, ``minute`` or ``second``.
             duration: The duration of each split.
 
         Returns:
-            A list of ``ee.ImageCollection`` grouped by interval
+            A list of :py:class:`ee.ImageCollection` grouped by interval
 
         Examples:
             .. code-block:: python
@@ -973,18 +973,18 @@ class ImageCollectionAccessor:
     ) -> ee.ImageCollection:
         """Reduce the images included in the same duration interval using the provided reducer.
 
-        For example using unit as "month" and duration as 1, the ``ee.ImageCollection`` will be reduced
-        into a new ``ee.ImageCollection`` with each image containing the reduced values for each month.
+        For example using unit as "month" and duration as 1, the :py:class:`ee.ImageCollection` will be reduced
+        into a new :py:class:`ee.ImageCollection` with each image containing the reduced values for each month.
         Make sure the collection is filtered beforehand to reduce the number of images that needs to be
         processed.
 
         Args:
             reducer: The name of the reducer to use or a Reducer object. Default is ``"mean"``.
-            unit: The unit of time to split the collection. Available units: ``'year'``, ``'month'``, ``'week'``, ``'day'``, ``'hour'``, ``'minute'`` or ``'second'``.
+            unit: The unit of time to split the collection. Available units: ``year``, ``month``, ``week``, ``day``, ``hour``, ``minute`` or ``second``.
             duration: The duration of each split.
 
         Returns:
-            A new ``ee.ImageCollection`` with the reduced images.
+            A new :py:class:`ee.ImageCollection` with the reduced images.
 
         Examples:
             .. code-block:: python
@@ -1031,7 +1031,7 @@ class ImageCollectionAccessor:
         As the imageCollection will need to be sorted limit the analysis to a reasonable number of image by filtering your data beforehand.
 
         Returns:
-            An ``ee.ImageCollection`` with all pixels unmasked in every image.
+            An :py:class:`ee.ImageCollection` with all pixels unmasked in every image.
 
         Examples:
             .. code-block:: python
@@ -1062,13 +1062,13 @@ class ImageCollectionAccessor:
         return ee.ImageCollection(imageList)
 
     def medoid(self) -> ee.Image:
-        """Compute the medoid of the ImageCollection.
+        """Compute the medoid of the :py:class:`ee.ImageCollection`.
 
         The medoid is the image that has the smallest sum of distances to all other images in the collection.
         The distance is computed using the Euclidean distance between the pixels of the images.
 
         Returns:
-            An Image that is the medoid of the ImageCollection.
+            An Image that is the medoid of the :py:class:`ee.ImageCollection`
 
         Examples:
             .. code-block:: python
@@ -1376,7 +1376,7 @@ class ImageCollectionAccessor:
 
         ic = self._obj.map(doy_tag)
 
-        # create a list of ImageCollection where every images of the same day are grouped together
+        # create a list of :py:class:`ee.ImageCollection` where every images of the same day are grouped together
         dayList = ee.List.sequence(0, 366)
 
         def filter_doy(d: ee.Number) -> ee.ImageCollection:
@@ -2130,7 +2130,7 @@ class ImageCollectionAccessor:
         """Plot the reduced data for each image in the collection by years for a single band.
 
         This method is plotting the reduced data for each image in the collection by years for a single band.
-        To set the start and end of the season, use the :py:method:`ee.Date.getRelative` or :py:class:`time.struct_time` method to get the day of the year.
+        To set the start and end of the season, use the :py:meth:`ee.Date.getRelative` or :py:class:`time.struct_time` method to get the day of the year.
 
         Parameters:
             band: The band to reduce.
@@ -2473,7 +2473,7 @@ class ImageCollectionAccessor:
     ) -> ee.FeatureCollection:
         """Apply a reducer to all the pixels in specific regions on each images of a collection.
 
-        The result will be shaped as a FeatureCollection with the idProperty as key and for each of them the reduced band values over one region.
+        The result will be shaped as a :py:class:`ee.FeatureCollection` with the ``idProperty`` as key and for each of them the reduced band values over one region.
         Each feature will have the same properties as the original feature collection and thus be identified by a key pair:
         "system:id" + "system:image_property"
 

--- a/geetools/ee_image_collection.py
+++ b/geetools/ee_image_collection.py
@@ -96,6 +96,9 @@ class ImageCollectionAccessor:
             cdi,
         )
 
+    # TODO: This method takes a lot of time, but it seems that is a problem of ee-extra.
+    #  By the way, I can't understad why. This is the source code:
+    #  https://github.com/r-earthengine/ee_extra/blob/master/ee_extra/ImageCollection/core.py
     def closest(
         self, date: ee.Date | str, tolerance: int = 1, unit: str = "month"
     ) -> ee.ImageCollection:
@@ -111,7 +114,7 @@ class ImageCollectionAccessor:
             Closest images to the specified date.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee
                 import geetools

--- a/geetools/ee_image_collection.py
+++ b/geetools/ee_image_collection.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime as dt
+from typing import Any
 
 import ee
 import ee_extra
@@ -113,7 +114,7 @@ class ImageCollectionAccessor:
             Closest images to the specified date.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee
                 import geetools
@@ -220,7 +221,7 @@ class ImageCollectionAccessor:
         )
         # fmt: on
 
-    def getScaleParams(self) -> dict:
+    def getScaleParams(self) -> dict[str, float]:
         """Gets the scale parameters for each band of the image.
 
         Returns:
@@ -231,7 +232,7 @@ class ImageCollectionAccessor:
             - :docstring:`ee.ImageCollection.geetools.scaleAndOffset`
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee
                 import geetools
@@ -242,7 +243,7 @@ class ImageCollectionAccessor:
         """
         return ee_extra.STAC.core.getScaleParams(self._obj)
 
-    def getOffsetParams(self) -> dict:
+    def getOffsetParams(self) -> dict[str, float]:
         """Gets the offset parameters for each band of the image.
 
         Returns:
@@ -253,7 +254,7 @@ class ImageCollectionAccessor:
             - :docstring:`ee.ImageCollection.geetools.scaleAndOffset`
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee
                 import geetools
@@ -311,14 +312,14 @@ class ImageCollectionAccessor:
         """
         return ee_extra.QA.pipelines.preprocess(self._obj, **kwargs)
 
-    def getSTAC(self) -> dict:
+    def getSTAC(self) -> dict[str, Any]:
         """Gets the STAC of the image collection.
 
         Returns:
             STAC of the image collection.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee
                 import geetools
@@ -357,7 +358,7 @@ class ImageCollectionAccessor:
             - :docstring:`ee.ImageCollection.geetools.getCitation`
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee
                 import geetools
@@ -378,7 +379,7 @@ class ImageCollectionAccessor:
             - :docstring:`ee.ImageCollection.geetools.getDOI`
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee
                 import geetools
@@ -489,7 +490,7 @@ class ImageCollectionAccessor:
             ImageCollection with the new image appended.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 
@@ -539,7 +540,7 @@ class ImageCollectionAccessor:
             ee.Image at the specified index.
 
         Examples:
-            .. jupyter-execute::
+            .. code-block:: python
 
                 import ee, geetools
 

--- a/geetools/ee_initialize.py
+++ b/geetools/ee_initialize.py
@@ -24,7 +24,7 @@ class InitializeAccessor:
         """Initialize Earthengine API using a specific user.
 
         Equivalent to the ``ee.initialize`` function but with a specific credential file stored in
-        the machine by the :py:meth:`ee.Authenticate.geetools.new_user <geetools.ee_autheticate.AuthenticateAccessor.new_user>`
+        the machine by the :py:meth:`ee.Authenticate.geetools.new_user <geetools.ee_authenticate.AuthenticateAccessor.new_user>`
         function.
 
         Args:

--- a/geetools/ee_initialize.py
+++ b/geetools/ee_initialize.py
@@ -1,4 +1,4 @@
-"""Tools for the ``ee.Initialize`` function."""
+"""Tools for the :py:func:`ee.Initialize` function."""
 from __future__ import annotations
 
 import json
@@ -23,7 +23,7 @@ class InitializeAccessor:
     def from_user(name: str = "", credential_pathname: str = "", project: str = "") -> None:
         """Initialize Earthengine API using a specific user.
 
-        Equivalent to the ``ee.initialize`` function but with a specific credential file stored in
+        Equivalent to the :py:func:`ee.Initialize` function but with a specific credential file stored in
         the machine by the :py:meth:`ee.Authenticate.geetools.new_user <geetools.ee_authenticate.AuthenticateAccessor.new_user>`
         function.
 
@@ -74,7 +74,7 @@ class InitializeAccessor:
     def from_service_account(private_key: str) -> None:
         """Initialize Earthengine API using a service account.
 
-        Equivalent to the ``ee.initialize`` function but with a specific service account json key.
+        Equivalent to the :py:func:`ee.Initialize` function but with a specific service account json key.
 
         Args:
             private_key: The private key of the service account in json format.

--- a/geetools/ee_join.py
+++ b/geetools/ee_join.py
@@ -10,29 +10,29 @@ from .accessors import register_class_accessor
 class JoinAccessor:
     """Toolbox for the :py:class:`ee.Join` class."""
 
-    def __init__(self, obj: ee.join):
+    def __init__(self, obj: ee.Join):
         """Initialize the Join class."""
         self._obj = obj
 
     @staticmethod
     def byProperty(
-        primary: ee.Collection,
-        secondary: ee.Collection,
+        primary: ee.FeatureCollection,
+        secondary: ee.FeatureCollection,
         field: str | ee.String,
         outer: bool = False,
-    ) -> ee.Collection:
+    ) -> ee.FeatureCollection:
         """Join 2 collections by a given property field.
 
-        It assumes ids are unique so uses ee.Join.saveFirst.
+        It assumes ids are unique so uses :py:meth:`ee.Join.saveFirst`.
 
         Args:
-            primary: the first collection
-            secondary: the second collection
-            field: the field to join by
-            outer: whether to keep non-matching features
+            primary: The first collection.
+            secondary: The second collection.
+            field: The field to join by.
+            outer: Whether to keep non-matching features.
 
         Returns:
-            the joined collection
+            The joined collection.
 
 
         Example:

--- a/geetools/ee_join.py
+++ b/geetools/ee_join.py
@@ -1,4 +1,4 @@
-"""Extra methods for the ``ee.Join`` class."""
+"""Extra methods for the :py:class:`ee.Join` class."""
 from __future__ import annotations
 
 import ee
@@ -8,7 +8,7 @@ from .accessors import register_class_accessor
 
 @register_class_accessor(ee.Join, "geetools")
 class JoinAccessor:
-    """Toolbox for the ``ee.Join`` class."""
+    """Toolbox for the :py:class:`ee.Join` class."""
 
     def __init__(self, obj: ee.join):
         """Initialize the Join class."""

--- a/geetools/ee_join.py
+++ b/geetools/ee_join.py
@@ -29,7 +29,7 @@ class JoinAccessor:
             primary: the first collection
             secondary: the second collection
             field: the field to join by
-            outer: whether to keep non matching features
+            outer: whether to keep non-matching features
 
         Returns:
             the joined collection

--- a/geetools/ee_list.py
+++ b/geetools/ee_list.py
@@ -211,7 +211,7 @@ class ListAccessor:
         list = keys.iterate(lambda k, p: ee.List(p).replace(k, replace.get(k)), self._obj)
         return ee.List(list)  # to avoid returning a ComputedObject
 
-    def join(self, separator: str | ee.String = ", ") -> ee.string:
+    def join(self, separator: str | ee.String = ", ") -> ee.String:
         """Format a list to a string.
 
         Same as the join method but elements that cannot be stringified will be returned as the object type.

--- a/geetools/ee_list.py
+++ b/geetools/ee_list.py
@@ -159,7 +159,7 @@ class ListAccessor:
     ) -> ee.List:
         """Create a sequence from ini to end by step.
 
-        Similar to ``ee.List.sequence``, but if end != last item then adds the end to the end of the resuting list.
+        Similar to ``ee.List.sequence``, but if end != last item then adds the end to the end of the resulting list.
 
         Parameters:
             ini: The initial value of the sequence.
@@ -214,7 +214,7 @@ class ListAccessor:
     def join(self, separator: str | ee.String = ", ") -> ee.String:
         """Format a list to a string.
 
-        Same as the join method but elements that cannot be stringified will be returned as the object type.
+        Same as the join method but elements that cannot be stringtified will be returned as the object type.
 
         Parameters:
             separator: The separator to use.

--- a/geetools/ee_list.py
+++ b/geetools/ee_list.py
@@ -159,7 +159,7 @@ class ListAccessor:
     ) -> ee.List:
         """Create a sequence from ini to end by step.
 
-        Similar to ``ee.List.sequence``, but if end != last item then adds the end to the end of the resulting list.
+        Similar to :py:meth:`ee.List.sequence`, but if ``end != last`` item then adds the end to the end of the resulting list.
 
         Parameters:
             ini: The initial value of the sequence.
@@ -191,7 +191,7 @@ class ListAccessor:
             replace: the dictionary with the values to replace. the keys are the values to replace and the values are the new values.
 
         Returns:
-            A list with the values replaced
+            A list with the values replaced.
 
         Examples:
             .. jupyter-execute::
@@ -239,7 +239,7 @@ class ListAccessor:
     def toStrings(self) -> ee.List:
         """Convert elements of a list into Strings.
 
-        If the list contains other elements that are not strings or numbers, it will return the object type. For example, ['a', 1, ee.Image(0)] -> ['a', '1', 'Image'].
+        If the list contains other elements that are not strings or numbers, it will return the object type. For example, ``['a', 1, ee.Image(0)] -> ['a', '1', 'Image']``.
 
         Returns:
             A list of strings corresponding to the elements of the list.
@@ -271,7 +271,7 @@ class ListAccessor:
         The nested lists need to all have the same size. The size of the first element will be taken as reference.
 
         Returns:
-            A list of lists with the zipped elements
+            A list of lists with the zipped elements.
 
         Examples:
             .. jupyter-execute::

--- a/geetools/ee_list.py
+++ b/geetools/ee_list.py
@@ -1,4 +1,4 @@
-"""Extra methods for the ``ee.List`` class."""
+"""Extra methods for the :py:class:`ee.List` class."""
 from __future__ import annotations
 
 import ee
@@ -8,7 +8,7 @@ from .accessors import register_class_accessor
 
 @register_class_accessor(ee.List, "geetools")
 class ListAccessor:
-    """Toolbox for the ``ee.List`` class."""
+    """Toolbox for the :py:class:`ee.List` class."""
 
     def __init__(self, obj: ee.List):
         """Initialize the List class."""

--- a/geetools/ee_list.py
+++ b/geetools/ee_list.py
@@ -223,7 +223,7 @@ class ListAccessor:
             A string with the list elements separated by commas.
 
         Examples:
-            .. juptyer-execute::
+            .. jupyter-execute::
 
                 import ee, geetools
                 from geetools.utils import initialize_documentation
@@ -245,7 +245,7 @@ class ListAccessor:
             A list of strings corresponding to the elements of the list.
 
         Examples:
-            .. juptyer-execute::
+            .. jupyter-execute::
 
                 import ee, geetools
                 from geetools.utils import initialize_documentation

--- a/geetools/ee_number.py
+++ b/geetools/ee_number.py
@@ -1,4 +1,4 @@
-"""Extra methods for the ``ee.Number`` class."""
+"""Extra methods for the :py:class:`ee.Number` class."""
 from __future__ import annotations
 
 import ee
@@ -8,7 +8,7 @@ from .accessors import register_class_accessor
 
 @register_class_accessor(ee.Number, "geetools")
 class NumberAccessor:
-    """toolbox for the ``ee.Number`` class."""
+    """toolbox for the :py:class:`ee.Number` class."""
 
     def __init__(self, obj: ee.Number):
         """Initialize the Number class."""

--- a/geetools/ee_profiler.py
+++ b/geetools/ee_profiler.py
@@ -73,7 +73,7 @@ class Profiler:
         return int(number * 10 ** mapping[multiplier])
 
     def _to_dict(self, input: str) -> dict:
-        """Transform the output of a Earthengine profiler into a dictionary compatible with pandas DataFrame."""
+        """Transform the output of an Earthengine profiler into a dictionary compatible with pandas DataFrame."""
         # Split the string into lines
         lines = input.strip().splitlines()
 

--- a/geetools/ee_string.py
+++ b/geetools/ee_string.py
@@ -1,4 +1,4 @@
-"""Extra methods for the ``ee.String`` class."""
+"""Extra methods for the :py:class:`ee.String` class."""
 from __future__ import annotations
 
 import ee
@@ -8,7 +8,7 @@ from .accessors import register_class_accessor
 
 @register_class_accessor(ee.String, "geetools")
 class StringAccessor:
-    """Toolbox for the ``ee.String`` class."""
+    """Toolbox for the :py:class:`ee.String` class."""
 
     def __init__(self, obj: ee.String):
         """Initialize the String class."""

--- a/geetools/utils.py
+++ b/geetools/utils.py
@@ -93,11 +93,11 @@ def plot_data(
 
     Args:
         type: The type of plot to use. can be any type of plot from the python lib `matplotlib.pyplot`. If the one you need is missing open an issue!
-        data: the data to use as inputs of the graph. please follow the fomrmat specified in the documentation.
+        data: the data to use as inputs of the graph. Please follow the format specified in the documentation.
         label_name: The name of the property that was used to generate the labels
         property_names: The list of names that was used to name the values. They will be used to order the keys of the data dictionary.
         colors: A list of colors to use for the plot. If not provided, the default colors from the matplotlib library will be used.
-        ax: The matplotlib axes to use. If not provided, the plot will be send to a new figure.
+        ax: The matplotlib axes to use. If not provided, the plot will be sent to a new figure.
         kwargs: Additional arguments from the ``pyplot`` chat type selected.
     """
     # define the ax if not provided by the user
@@ -243,7 +243,7 @@ def plot_data(
 
 
 def initialize_documentation():
-    """Initialize Earthe Engine Python API in the context of the Documentation build.
+    """Initialize Earth Engine Python API in the context of the Documentation build.
 
     Warning:
         This method is only used in the documentation build and should not be used in a production environment.


### PR DESCRIPTION
I realised that many methods have some bugs in their documentation. For instance, [`getOffsetParams`](https://geetools.readthedocs.io/en/stable/autoapi/geetools/ee_image/ImageAccessor.getOffsetParams.html) has an example which is not well idented.

This PR aims to fix these errors in the documentation.

The changes are:
- Fix a lot of typos in documentation.
- Improve the identation along the methods' documentation.
- Update examples to the new version (from `ee.ImageCollection(‘COPERNICUS/S2_SR’).first().getSTAC()` to `ee.ImageCollection(‘COPERNICUS/S2_SR’).first().geetools.getSTAC()`).
- Improve typing (for example, `getScaleParams` returns a `dict`, instead of `dict[str, float]` that is the complete typing, or update the wrong typing `ee.image` to `ee.Image`).
- Extend documentation to be more similar to ee-mont (if they correspond).
- Improve the cross reference (for external libraries, as matplotlib or gee).