### PR TITLE
fix: add back the system properties

### DIFF
--- a/geetools/ee_feature_collection.py
+++ b/geetools/ee_feature_collection.py
@@ -668,7 +668,9 @@ class FeatureCollectionAccessor:
 
         # get the data from the server
         names = self._obj.first().propertyNames()
-        names = names.filter(ee.Filter.stringStartsWith("item", "system:").Not())
+        nonSystemNames = names.filter(ee.Filter.stringStartsWith("item", "system:").Not()).sort()
+        systemNames = names.filter(ee.Filter.stringStartsWith("item", "system:")).sort()
+        names = nonSystemNames.cat(systemNames)
         property = property if property != "" else names.get(0).getInfo()
         data = self._obj.select([property]).getInfo()
 


### PR DESCRIPTION
Fix #384 

We were filtering out the system properties so on the fly generated FeatureCollection including property less features were crashing (as their only property was "system:index"). 

This PR is reordering the properties: 
- first the named properties 
- then the system one 

This maintains compatibility with older implementation (do your select before calling `plot`) and guarantees it's going to work with the propertyless features. 