### PR TITLE
refactor: improve typing and delete mutable default arguments

### DIFF
--- a/geetools/ee_authenticate.py
+++ b/geetools/ee_authenticate.py
@@ -1,6 +1,7 @@
 """Toolbox for the :py:func:`ee.Authenticate` function."""
 from __future__ import annotations
 
+import os
 from contextlib import suppress
 from pathlib import Path
 from shutil import move
@@ -16,7 +17,7 @@ class AuthenticateAccessor:
     """Create an accessor for the :py:func:`ee.Authenticate` function."""
 
     @staticmethod
-    def new_user(name: str = "", credential_pathname: str | Path = "") -> None:
+    def new_user(name: str = "", credential_pathname: str | os.PathLike = "") -> None:
         """Authenticate the user and save the credentials in a specific folder.
 
         Equivalent to :py:func:`ee.Authenticate` but where the registered user will not be the default one (the one you get when running :py:func:`ee.Initialize`).
@@ -55,7 +56,7 @@ class AuthenticateAccessor:
                 move(Path(dir) / default.name, default)
 
     @staticmethod
-    def delete_user(name: str = "", credential_pathname: str | Path = "") -> None:
+    def delete_user(name: str = "", credential_pathname: str | os.PathLike = "") -> None:
         """Delete a user credential file.
 
         Args:
@@ -80,7 +81,7 @@ class AuthenticateAccessor:
             (credential_path / name).unlink()
 
     @staticmethod
-    def list_user(credential_pathname: str | Path = "") -> list[str]:
+    def list_user(credential_pathname: str | os.PathLike = "") -> list[str]:
         """return all the available users in the set folder.
 
         To reach "default" simply omit the ``name`` parameter in the User methods.
@@ -105,7 +106,7 @@ class AuthenticateAccessor:
         return [f.name.replace("credentials", "") or "default" for f in files]
 
     @staticmethod
-    def rename_user(new: str, old: str = "", credential_pathname: str | Path = "") -> None:
+    def rename_user(new: str, old: str = "", credential_pathname: str | os.PathLike = "") -> None:
         """Rename a user without changing the credentials.
 
         Args:

--- a/geetools/ee_authenticate.py
+++ b/geetools/ee_authenticate.py
@@ -16,14 +16,14 @@ class AuthenticateAccessor:
     """Create an accessor for the :py:func:`ee.Authenticate` function."""
 
     @staticmethod
-    def new_user(name: str = "", credential_pathname: str = "") -> None:
+    def new_user(name: str = "", credential_pathname: str | Path = "") -> None:
         """Authenticate the user and save the credentials in a specific folder.
 
-        Equivalent to :py:func:`ee.Authenticate` but where the registered user will not be the default one (the one you get when running :py:func:`ee.Initialize`)
+        Equivalent to :py:func:`ee.Authenticate` but where the registered user will not be the default one (the one you get when running :py:func:`ee.Initialize`).
 
         Args:
             name: The name of the user. If not set, it will reauthenticate default.
-            credential_pathname: The path to the folder where the credentials are stored. If not set, it uses the default path
+            credential_pathname: The path to the folder where the credentials are stored. If not set, it uses the default path.
 
         Example:
             .. code-block:: python
@@ -55,12 +55,12 @@ class AuthenticateAccessor:
                 move(Path(dir) / default.name, default)
 
     @staticmethod
-    def delete_user(name: str = "", credential_pathname: str = "") -> None:
+    def delete_user(name: str = "", credential_pathname: str | Path = "") -> None:
         """Delete a user credential file.
 
         Args:
-            name: The name of the user. If not set, it will delete the default user
-            credential_pathname: The path to the folder where the credentials are stored. If not set, it uses the default path
+            name: The name of the user. If not set, it will delete the default user.
+            credential_pathname: The path to the folder where the credentials are stored. If not set, it uses the default path.
 
         Example:
             .. code-block:: python
@@ -80,16 +80,16 @@ class AuthenticateAccessor:
             (credential_path / name).unlink()
 
     @staticmethod
-    def list_user(credential_pathname: str = "") -> list[str]:
+    def list_user(credential_pathname: str | Path = "") -> list[str]:
         """return all the available users in the set folder.
 
-        To reach "default" simply omit the ``name`` parameter in the User methods
+        To reach "default" simply omit the ``name`` parameter in the User methods.
 
         Args:
-            credential_pathname: The path to the folder where the credentials are stored. If not set, it uses the default path
+            credential_pathname: The path to the folder where the credentials are stored. If not set, it uses the default path.
 
         Returns:
-            A list of strings with the names of the users
+            A list of strings with the names of the users.
 
         Example:
             .. code-block:: python
@@ -105,13 +105,13 @@ class AuthenticateAccessor:
         return [f.name.replace("credentials", "") or "default" for f in files]
 
     @staticmethod
-    def rename_user(new: str, old: str = "", credential_pathname: str = "") -> None:
+    def rename_user(new: str, old: str = "", credential_pathname: str | Path = "") -> None:
         """Rename a user without changing the credentials.
 
         Args:
-            new: The new name of the user
-            old: The name of the user to rename
-            credential_pathname: The path to the folder where the credentials are stored. If not set, it uses the default path
+            new: The new name of the user.
+            old: The name of the user to rename.
+            credential_pathname: The path to the folder where the credentials are stored. If not set, it uses the default path.
 
         Example:
             .. code-block:: python

--- a/geetools/ee_authenticate.py
+++ b/geetools/ee_authenticate.py
@@ -17,7 +17,7 @@ class AuthenticateAccessor:
     """Create an accessor for the :py:func:`ee.Authenticate` function."""
 
     @staticmethod
-    def new_user(name: str = "", credential_pathname: str | os.PathLike = "") -> None:
+    def new_user(name: str = "", credential_pathname: str | os.PathLike = ""):
         """Authenticate the user and save the credentials in a specific folder.
 
         Equivalent to :py:func:`ee.Authenticate` but where the registered user will not be the default one (the one you get when running :py:func:`ee.Initialize`).
@@ -56,7 +56,7 @@ class AuthenticateAccessor:
                 move(Path(dir) / default.name, default)
 
     @staticmethod
-    def delete_user(name: str = "", credential_pathname: str | os.PathLike = "") -> None:
+    def delete_user(name: str = "", credential_pathname: str | os.PathLike = ""):
         """Delete a user credential file.
 
         Args:
@@ -106,7 +106,7 @@ class AuthenticateAccessor:
         return [f.name.replace("credentials", "") or "default" for f in files]
 
     @staticmethod
-    def rename_user(new: str, old: str = "", credential_pathname: str | os.PathLike = "") -> None:
+    def rename_user(new: str, old: str = "", credential_pathname: str | os.PathLike = ""):
         """Rename a user without changing the credentials.
 
         Args:

--- a/geetools/ee_feature.py
+++ b/geetools/ee_feature.py
@@ -18,7 +18,7 @@ class FeatureAccessor:
         """Convert a :py:class:`ee.Feature` composed of a multiGeometry geometry into a :py:class:`ee.FeatureCollection`.
 
         Returns:
-            The :py:class:`ee.FeatureCollection`
+            The :py:class:`ee.FeatureCollection`.
 
         Example:
             .. jupyter-execute::
@@ -37,14 +37,14 @@ class FeatureAccessor:
         fc = geoms.map(lambda g: self._obj.setGeometry(g))
         return ee.FeatureCollection(fc)
 
-    def removeProperties(self, properties: list | ee.List) -> ee.Feature:
+    def removeProperties(self, properties: list[str] | ee.List) -> ee.Feature:
         """Remove properties from a feature.
 
         Args:
-            properties : List of properties to remove
+            properties : List of properties to remove.
 
         Returns:
-            The feature without the properties
+            The feature without the properties.
 
         Example:
             .. jupyter-execute::

--- a/geetools/ee_feature_collection.py
+++ b/geetools/ee_feature_collection.py
@@ -275,7 +275,7 @@ class FeatureCollectionAccessor:
         self,
         featureId: str | ee.String = "system:index",
         properties: list[str] | ee.List | None = None,
-        labels: list[str] | None = None,
+        labels: list[str] | ee.List | None = None,
     ) -> ee.Dictionary:
         """Get a dictionary with all feature values for each property.
 
@@ -340,7 +340,7 @@ class FeatureCollectionAccessor:
         self,
         featureId: str | ee.String = "system:index",
         properties: list[str] | ee.List | None = None,
-        labels: list[str] | None = None,
+        labels: list[str] | ee.List | None = None,
     ) -> ee.Dictionary:
         """Get a dictionary with all property values for each feature.
 

--- a/geetools/ee_feature_collection.py
+++ b/geetools/ee_feature_collection.py
@@ -127,7 +127,7 @@ class FeatureCollectionAccessor:
                 print(json.dumps(countries.getInfo(), indent=2))
         """
         uniqueIds = self._obj.aggregate_array(keyColumn)
-        selectors = ee.List(selectors) if selectors else self._obj.first().propertyNames()
+        selectors = ee.List(selectors) if selectors is None else self._obj.first().propertyNames()
         keyColumn = ee.String(keyColumn)
 
         features = self._obj.toList(self._obj.size())
@@ -321,14 +321,16 @@ class FeatureCollectionAccessor:
         features = features.map(lambda i: ee.Algorithms.If(isString(i), i, ee.Number(i).format()))
 
         # retrieve properties for each feature
-        properties = ee.List(properties) if properties else self._obj.first().propertyNames()
+        properties = (
+            ee.List(properties) if properties is None else self._obj.first().propertyNames()
+        )
         properties = properties.remove(featureId)
         values = properties.map(
             lambda p: ee.Dictionary.fromLists(features, self._obj.aggregate_array(p))
         )
 
         # get the label to use in the dictionary if requested
-        labels = ee.List(labels) if labels else properties
+        labels = ee.List(labels) if labels is None else properties
 
         return ee.Dictionary.fromLists(labels, values)
 
@@ -380,9 +382,9 @@ class FeatureCollectionAccessor:
 
         """
         # compute the properties and their labels
-        props = ee.List(properties) if properties else self._obj.first().propertyNames()
+        props = ee.List(properties) if properties is None else self._obj.first().propertyNames()
         props = props.remove(featureId)
-        labels = ee.List(labels) if labels else props
+        labels = ee.List(labels) if labels is None else props
 
         # create a function to get the properties of a feature
         # we need to map the featureCollection into a list as it's not possible to return something else than a
@@ -455,14 +457,18 @@ class FeatureCollectionAccessor:
                     label.set_rotation(45)
         """
         # Get the features and properties
-        props = ee.List(properties) if properties else self._obj.first().propertyNames().getInfo()
+        props = (
+            ee.List(properties)
+            if properties is None
+            else self._obj.first().propertyNames().getInfo()
+        )
         props = props.remove(featureId)
 
         # get the data from server
         data = self.byProperties(featureId, props, labels).getInfo()
 
         # reorder the data according to the labels or properties set by the user
-        labels = labels if labels else props.getInfo()
+        labels = labels if labels is None else props.getInfo()
         data = {k: data[k] for k in labels}
 
         return plot_data(type=type, data=data, label_name=featureId, colors=colors, ax=ax, **kwargs)
@@ -518,14 +524,14 @@ class FeatureCollectionAccessor:
         """
         # Get the features and properties
         fc = self._obj
-        props = ee.List(properties) if properties else fc.first().propertyNames()
+        props = ee.List(properties) if properties is None else fc.first().propertyNames()
         props = props.remove(featureId)
 
         # get the data from server
         data = self.byFeatures(featureId, props, labels).getInfo()
 
         # reorder the data according to the lapbes or properties set by the user
-        labels = labels if labels else props.getInfo()
+        labels = labels if labels is None else props.getInfo()
         data = {f: {k: data[f][k] for k in labels} for f in data.keys()}
 
         return plot_data(type=type, data=data, label_name=featureId, colors=colors, ax=ax, **kwargs)

--- a/geetools/ee_feature_collection.py
+++ b/geetools/ee_feature_collection.py
@@ -93,7 +93,9 @@ class FeatureCollectionAccessor:
         return ee.Image().paint(self._obj, **params)
 
     def toDictionary(
-        self, keyColumn: str | ee.String = "system:index", selectors: list | ee.List = []
+        self,
+        keyColumn: str | ee.String = "system:index",
+        selectors: list[str] | ee.List | None = None,
     ) -> ee.Dictionary:
         """Convert to Dictionary.
 
@@ -270,8 +272,8 @@ class FeatureCollectionAccessor:
     def byProperties(
         self,
         featureId: str | ee.String = "system:index",
-        properties: list | ee.List = [],
-        labels: list = [],
+        properties: list[str] | ee.List | None = None,
+        labels: list[str] | None = None,
     ) -> ee.Dictionary:
         """Get a dictionary with all feature values for each property.
 
@@ -289,7 +291,7 @@ class FeatureCollectionAccessor:
 
         Args:
             featureId: The property used to label features. Defaults to ``"system:index"``.
-            properties: A list of properties to get the values from.
+            properties: A list of properties to get the values from. By default, all properties will be used.
             labels: A list of names to replace properties names. Default to the properties names.
 
         Returns:
@@ -333,8 +335,8 @@ class FeatureCollectionAccessor:
     def byFeatures(
         self,
         featureId: str | ee.String = "system:index",
-        properties: list | ee.List = [],
-        labels: list = [],
+        properties: list[str] | ee.List | None = None,
+        labels: list[str] | None = None,
     ) -> ee.Dictionary:
         """Get a dictionary with all property values for each feature.
 
@@ -352,7 +354,7 @@ class FeatureCollectionAccessor:
 
         Args:
             featureId: The property to use as the feature id. Defaults to ``"system:index"``. This property needs to be a string property.
-            properties: A list of properties to get the values from.
+            properties: A list of properties to get the values from. By default, all properties will be used.
             labels: A list of names to replace properties names. Default to the properties names.
 
         Returns:
@@ -401,9 +403,9 @@ class FeatureCollectionAccessor:
         self,
         type: str = "bar",
         featureId: str = "system:index",
-        properties: list = [],
-        labels: list = [],
-        colors: list = [],
+        properties: list[str] | None = None,
+        labels: list[str] | None = None,
+        colors: list[str] | None = None,
         ax: Axes | None = None,
         **kwargs,
     ) -> Axes:
@@ -469,9 +471,9 @@ class FeatureCollectionAccessor:
         self,
         type: str = "bar",
         featureId: str = "system:index",
-        properties: list | ee.List = [],
-        labels: list = [],
-        colors: list = [],
+        properties: list[str] | ee.List | None = None,
+        labels: list[str] | None = None,
+        colors: list[str] | None = None,
         ax: Axes | None = None,
         **kwargs,
     ) -> Axes:
@@ -533,7 +535,7 @@ class FeatureCollectionAccessor:
         property: str | ee.String,
         label: str = "",
         ax: Axes | None = None,
-        color=None,
+        color: str | None = None,
         **kwargs,
     ) -> Axes:
         """Plot the histogram of a specific property.

--- a/geetools/ee_feature_collection.py
+++ b/geetools/ee_feature_collection.py
@@ -127,7 +127,9 @@ class FeatureCollectionAccessor:
                 print(json.dumps(countries.getInfo(), indent=2))
         """
         uniqueIds = self._obj.aggregate_array(keyColumn)
-        selectors = ee.List(selectors) if selectors is None else self._obj.first().propertyNames()
+        selectors = (
+            ee.List(selectors) if selectors is not None else self._obj.first().propertyNames()
+        )
         keyColumn = ee.String(keyColumn)
 
         features = self._obj.toList(self._obj.size())
@@ -322,7 +324,7 @@ class FeatureCollectionAccessor:
 
         # retrieve properties for each feature
         properties = (
-            ee.List(properties) if properties is None else self._obj.first().propertyNames()
+            ee.List(properties) if properties is not None else self._obj.first().propertyNames()
         )
         properties = properties.remove(featureId)
         values = properties.map(
@@ -330,7 +332,7 @@ class FeatureCollectionAccessor:
         )
 
         # get the label to use in the dictionary if requested
-        labels = ee.List(labels) if labels is None else properties
+        labels = ee.List(labels) if labels is not None else properties
 
         return ee.Dictionary.fromLists(labels, values)
 
@@ -382,9 +384,9 @@ class FeatureCollectionAccessor:
 
         """
         # compute the properties and their labels
-        props = ee.List(properties) if properties is None else self._obj.first().propertyNames()
+        props = ee.List(properties) if properties is not None else self._obj.first().propertyNames()
         props = props.remove(featureId)
-        labels = ee.List(labels) if labels is None else props
+        labels = ee.List(labels) if labels is not None else props
 
         # create a function to get the properties of a feature
         # we need to map the featureCollection into a list as it's not possible to return something else than a
@@ -459,7 +461,7 @@ class FeatureCollectionAccessor:
         # Get the features and properties
         props = (
             ee.List(properties)
-            if properties is None
+            if properties is not None
             else self._obj.first().propertyNames().getInfo()
         )
         props = props.remove(featureId)
@@ -468,7 +470,7 @@ class FeatureCollectionAccessor:
         data = self.byProperties(featureId, props, labels).getInfo()
 
         # reorder the data according to the labels or properties set by the user
-        labels = labels if labels is None else props.getInfo()
+        labels = labels if labels is not None else props.getInfo()
         data = {k: data[k] for k in labels}
 
         return plot_data(type=type, data=data, label_name=featureId, colors=colors, ax=ax, **kwargs)
@@ -524,14 +526,14 @@ class FeatureCollectionAccessor:
         """
         # Get the features and properties
         fc = self._obj
-        props = ee.List(properties) if properties is None else fc.first().propertyNames()
+        props = ee.List(properties) if properties is not None else fc.first().propertyNames()
         props = props.remove(featureId)
 
         # get the data from server
         data = self.byFeatures(featureId, props, labels).getInfo()
 
         # reorder the data according to the lapbes or properties set by the user
-        labels = labels if labels is None else props.getInfo()
+        labels = labels if labels is not None else props.getInfo()
         data = {f: {k: data[f][k] for k in labels} for f in data.keys()}
 
         return plot_data(type=type, data=data, label_name=featureId, colors=colors, ax=ax, **kwargs)

--- a/geetools/ee_image.py
+++ b/geetools/ee_image.py
@@ -2105,7 +2105,8 @@ class ImageAccessor:
         eeBands = ee.List(bands) if bands else self._obj.bandNames()
         # TODO: Same here
         eeLabels = ee.List(labels).flatten() if labels else eeBands
-        labels = eeLabels.getInfo()
+        new_labels: list[str] = eeLabels.getInfo()
+        new_colors: list[str] = colors if colors else plt.get_cmap("tab10").colors
 
         # retrieve the region from the parameters
         region = region if region else self._obj.geometry()
@@ -2141,17 +2142,17 @@ class ImageAccessor:
         # every value is duplicated but the first one to create a scale like display.
         # the values are treated the same way we simply drop the last duplication to get the same size.
         p = 10**precision  # multiplier use to truncate the float values
-        x = [int(d[0] * p) / p for d in raw_data[labels[0]] for _ in range(2)][1:]
-        data = {l: [int(d[1]) for d in raw_data[l] for _ in range(2)][:-1] for l in labels}
+        x = [int(d[0] * p) / p for d in raw_data[new_labels[0]] for _ in range(2)][1:]
+        data = {l: [int(d[1]) for d in raw_data[l] for _ in range(2)][:-1] for l in new_labels}
 
         # create the graph objcet if not provided
         if ax is None:
             fig, ax = plt.subplots()
 
         # display the histogram as a fill_between plot to respect GEE lib design
-        for i, label in enumerate(labels):
-            kwargs["facecolor"] = to_rgba(colors[i], 0.2)
-            kwargs["edgecolor"] = to_rgba(colors[i], 1)
+        for i, label in enumerate(new_labels):
+            kwargs["facecolor"] = to_rgba(new_colors[i], 0.2)
+            kwargs["edgecolor"] = to_rgba(new_colors[i], 1)
             ax.fill_between(x, data[label], label=label, **kwargs)
 
         # customize the layout of the axis

--- a/geetools/ee_image.py
+++ b/geetools/ee_image.py
@@ -61,7 +61,7 @@ class ImageAccessor:
         """
         # parse the inputs
         isMillis = ee.String(format).equals(ee.String(""))
-        format = ee.String(format) if format is None else ee.String("YYYYMMdd")
+        format = ee.String(format) if format else ee.String("YYYYMMdd")
 
         # extract the date from the object and create a image band from it
         date = self._obj.date()
@@ -96,7 +96,7 @@ class ImageAccessor:
                 print(image.bandNames().getInfo())
         """
         suffix = ee.String(suffix)
-        bands = self._obj.bandNames() if bands is None else ee.List(bands)
+        bands = ee.List(bands) if bands is not None else self._obj.bandNames()
         bandNames = bands.iterate(
             lambda b, n: ee.List(n).replace(b, ee.String(b).cat(suffix)),
             self._obj.bandNames(),
@@ -129,7 +129,7 @@ class ImageAccessor:
                 print(image.bandNames().getInfo())
         """
         prefix = ee.String(prefix)
-        bands = self._obj.bandNames() if bands is None else ee.List(bands)
+        bands = ee.List(bands) if bands is not None else self._obj.bandNames()
         bandNames = bands.iterate(
             lambda b, n: ee.List(n).replace(b, prefix.cat(ee.String(b))),
             self._obj.bandNames(),
@@ -222,7 +222,7 @@ class ImageAccessor:
                 print(image.reduceRegion(ee.Reducer.min(), vatican, 1).getInfo())
         """
         year = ee.Number(year)
-        band = ee.String(band) if band is None else ee.String(self._obj.bandNames().get(0))
+        band = ee.String(band) if band else ee.String(self._obj.bandNames().get(0))
         dateFormat = ee.String(dateFormat)
 
         doyList = ee.List.sequence(0, 365)
@@ -345,7 +345,7 @@ class ImageAccessor:
                 grid = image.geetools.toGrid(1, 'B2', buffer)
                 print(grid.getInfo())
         """
-        band = ee.String(band) if band is None else self._obj.bandNames().get(0)
+        band = ee.String(band) if band else self._obj.bandNames().get(0)
         projection = self._obj.select(band).projection()
         size = projection.nominalScale().multiply(ee.Number(size).toInt())
 
@@ -468,8 +468,8 @@ class ImageAccessor:
                 image = ee.Image.geetools.full([1, 2, 3], ['a', 'b', 'c'])
                 print(image.bandNames().getInfo())
         """
-        values = ee.List(values) if values is None else ee.List([0])
-        names = ee.List(names) if names is None else ee.List(["constant"])
+        values = ee.List(values) if values is not None else ee.List([0])
+        names = ee.List(names) if names is not None else ee.List(["constant"])
 
         # resize value to the same length as names
         values = ee.List(
@@ -573,7 +573,7 @@ class ImageAccessor:
         if not isinstance(reducer, str):
             raise TypeError("reducer must be a Python string")
 
-        bands = ee.List(bands) if bands is None else ee.List([])
+        bands = ee.List(bands) if bands is not None else ee.List([])
         name = ee.String(name)
         bands = ee.Algorithms.If(bands.size().eq(0), self._obj.bandNames(), bands)
         name = ee.Algorithms.If(name.equals(ee.String("")), reducer, name)
@@ -678,7 +678,7 @@ class ImageAccessor:
                 image = image.geetools.gauss()
                 print(image.bandNames().getInfo())
         """
-        band = ee.String(band) if band is None else ee.String(self._obj.bandNames().get(0))
+        band = ee.String(band) if band else ee.String(self._obj.bandNames().get(0))
         image = self._obj.select(band)
 
         kwargs = {"geometry": image.geometry(), "bestEffort": True}
@@ -1739,10 +1739,10 @@ class ImageAccessor:
         features = features.map(lambda i: ee.Algorithms.If(isString(i), i, ee.Number(i).format()))
 
         # get the bands to be used in the reducer
-        eeBands = ee.List(bands) if bands is None else self._obj.bandNames()
+        eeBands = ee.List(bands) if bands is not None else self._obj.bandNames()
 
         # retrieve the label to use for each bands if provided
-        eeLabels = ee.List(labels) if labels is None else eeBands
+        eeLabels = ee.List(labels) if labels is not None else eeBands
 
         # by default for 1 band image, the reducers are renaming the output band. To ensure it keeps
         #  the original band name we add setOutputs that is ignored for multi band images.
@@ -1830,10 +1830,10 @@ class ImageAccessor:
         features = features.map(lambda i: ee.Algorithms.If(isString(i), i, ee.Number(i).format()))
 
         # get the bands to be used in the reducer
-        bands = ee.List(bands) if bands is None else self._obj.bandNames()
+        bands = ee.List(bands) if bands is not None else self._obj.bandNames()
 
         # retrieve the label to use for each bands if provided
-        labels = ee.List(labels) if labels is None else bands
+        labels = ee.List(labels) if labels is not None else bands
 
         # by default for 1 band image, the reducers are renaming the output band. To ensure it keeps
         #  the original band name we add setOutputs that is ignored for multi band images.
@@ -1942,8 +1942,8 @@ class ImageAccessor:
         features = features.getInfo()
 
         # extract the labels from the parameters
-        eeBands = ee.List(bands) if bands is None else self._obj.bandNames()
-        labels = labels if labels is None else eeBands.getInfo()
+        eeBands = ee.List(bands) if bands is not None else self._obj.bandNames()
+        labels = labels if labels is not None else eeBands.getInfo()
 
         # reorder the data according to the labels id set by the user
         data = {b: {f: data[b][f] for f in features} for b in labels}
@@ -2033,8 +2033,8 @@ class ImageAccessor:
         features = features.getInfo()
 
         # extract the labels from the parameters
-        eeBands = ee.List(bands) if bands is None else self._obj.bandNames()
-        labels = labels if labels is None else eeBands.getInfo()
+        eeBands = ee.List(bands) if bands is not None else self._obj.bandNames()
+        labels = labels if labels is not None else eeBands.getInfo()
 
         # reorder the data according to the labels id set by the user
         data = {f: {b: data[f][b] for b in labels} for f in features}
@@ -2102,14 +2102,14 @@ class ImageAccessor:
         # TODO: In this case, the default is "to all bands",
         #  but the original implementation the default was an empty list.
         #  Is that correct?
-        eeBands = ee.List(bands) if bands is None else self._obj.bandNames()
+        eeBands = ee.List(bands) if bands is not None else self._obj.bandNames()
         # TODO: Same here
-        eeLabels = ee.List(labels).flatten() if labels is None else eeBands
+        eeLabels = ee.List(labels).flatten() if labels is not None else eeBands
         new_labels: list[str] = eeLabels.getInfo()
-        new_colors: list[str] = colors if colors is None else plt.get_cmap("tab10").colors
+        new_colors: list[str] = colors if colors is not None else plt.get_cmap("tab10").colors
 
         # retrieve the region from the parameters
-        region = region if region is None else self._obj.geometry()
+        region = region if region is not None else self._obj.geometry()
 
         # extract the data from the server
         image = self._obj.select(eeBands).rename(eeLabels).clip(region)

--- a/geetools/ee_image.py
+++ b/geetools/ee_image.py
@@ -2099,11 +2099,7 @@ class ImageAccessor:
                 normClim.geetools.plot_hist()
         """
         # extract the bands from the image
-        # TODO: In this case, the default is "to all bands",
-        #  but the original implementation the default was an empty list.
-        #  Is that correct?
         eeBands = ee.List(bands) if bands is not None else self._obj.bandNames()
-        # TODO: Same here
         eeLabels = ee.List(labels).flatten() if labels is not None else eeBands
         new_labels: list[str] = eeLabels.getInfo()
         new_colors: list[str] = colors if colors is not None else plt.get_cmap("tab10").colors

--- a/geetools/ee_image.py
+++ b/geetools/ee_image.py
@@ -61,7 +61,7 @@ class ImageAccessor:
         """
         # parse the inputs
         isMillis = ee.String(format).equals(ee.String(""))
-        format = ee.String(format) if format else ee.String("YYYYMMdd")
+        format = ee.String(format) if format is None else ee.String("YYYYMMdd")
 
         # extract the date from the object and create a image band from it
         date = self._obj.date()
@@ -222,7 +222,7 @@ class ImageAccessor:
                 print(image.reduceRegion(ee.Reducer.min(), vatican, 1).getInfo())
         """
         year = ee.Number(year)
-        band = ee.String(band) if band else ee.String(self._obj.bandNames().get(0))
+        band = ee.String(band) if band is None else ee.String(self._obj.bandNames().get(0))
         dateFormat = ee.String(dateFormat)
 
         doyList = ee.List.sequence(0, 365)
@@ -345,7 +345,7 @@ class ImageAccessor:
                 grid = image.geetools.toGrid(1, 'B2', buffer)
                 print(grid.getInfo())
         """
-        band = ee.String(band) if band else self._obj.bandNames().get(0)
+        band = ee.String(band) if band is None else self._obj.bandNames().get(0)
         projection = self._obj.select(band).projection()
         size = projection.nominalScale().multiply(ee.Number(size).toInt())
 
@@ -468,8 +468,8 @@ class ImageAccessor:
                 image = ee.Image.geetools.full([1, 2, 3], ['a', 'b', 'c'])
                 print(image.bandNames().getInfo())
         """
-        values = ee.List(values) if values else ee.List([0])
-        names = ee.List(names) if names else ee.List(["constant"])
+        values = ee.List(values) if values is None else ee.List([0])
+        names = ee.List(names) if names is None else ee.List(["constant"])
 
         # resize value to the same length as names
         values = ee.List(
@@ -573,7 +573,7 @@ class ImageAccessor:
         if not isinstance(reducer, str):
             raise TypeError("reducer must be a Python string")
 
-        bands = ee.List(bands) if bands else ee.List([])
+        bands = ee.List(bands) if bands is None else ee.List([])
         name = ee.String(name)
         bands = ee.Algorithms.If(bands.size().eq(0), self._obj.bandNames(), bands)
         name = ee.Algorithms.If(name.equals(ee.String("")), reducer, name)
@@ -678,7 +678,7 @@ class ImageAccessor:
                 image = image.geetools.gauss()
                 print(image.bandNames().getInfo())
         """
-        band = ee.String(band) if band else ee.String(self._obj.bandNames().get(0))
+        band = ee.String(band) if band is None else ee.String(self._obj.bandNames().get(0))
         image = self._obj.select(band)
 
         kwargs = {"geometry": image.geometry(), "bestEffort": True}
@@ -1739,10 +1739,10 @@ class ImageAccessor:
         features = features.map(lambda i: ee.Algorithms.If(isString(i), i, ee.Number(i).format()))
 
         # get the bands to be used in the reducer
-        eeBands = ee.List(bands) if bands else self._obj.bandNames()
+        eeBands = ee.List(bands) if bands is None else self._obj.bandNames()
 
         # retrieve the label to use for each bands if provided
-        eeLabels = ee.List(labels) if labels else eeBands
+        eeLabels = ee.List(labels) if labels is None else eeBands
 
         # by default for 1 band image, the reducers are renaming the output band. To ensure it keeps
         #  the original band name we add setOutputs that is ignored for multi band images.
@@ -1830,10 +1830,10 @@ class ImageAccessor:
         features = features.map(lambda i: ee.Algorithms.If(isString(i), i, ee.Number(i).format()))
 
         # get the bands to be used in the reducer
-        bands = ee.List(bands) if bands else self._obj.bandNames()
+        bands = ee.List(bands) if bands is None else self._obj.bandNames()
 
         # retrieve the label to use for each bands if provided
-        labels = ee.List(labels) if labels else bands
+        labels = ee.List(labels) if labels is None else bands
 
         # by default for 1 band image, the reducers are renaming the output band. To ensure it keeps
         #  the original band name we add setOutputs that is ignored for multi band images.
@@ -1942,8 +1942,8 @@ class ImageAccessor:
         features = features.getInfo()
 
         # extract the labels from the parameters
-        eeBands = ee.List(bands) if bands else self._obj.bandNames()
-        labels = labels if labels else eeBands.getInfo()
+        eeBands = ee.List(bands) if bands is None else self._obj.bandNames()
+        labels = labels if labels is None else eeBands.getInfo()
 
         # reorder the data according to the labels id set by the user
         data = {b: {f: data[b][f] for f in features} for b in labels}
@@ -2033,8 +2033,8 @@ class ImageAccessor:
         features = features.getInfo()
 
         # extract the labels from the parameters
-        eeBands = ee.List(bands) if bands else self._obj.bandNames()
-        labels = labels if labels else eeBands.getInfo()
+        eeBands = ee.List(bands) if bands is None else self._obj.bandNames()
+        labels = labels if labels is None else eeBands.getInfo()
 
         # reorder the data according to the labels id set by the user
         data = {f: {b: data[f][b] for b in labels} for f in features}
@@ -2102,14 +2102,14 @@ class ImageAccessor:
         # TODO: In this case, the default is "to all bands",
         #  but the original implementation the default was an empty list.
         #  Is that correct?
-        eeBands = ee.List(bands) if bands else self._obj.bandNames()
+        eeBands = ee.List(bands) if bands is None else self._obj.bandNames()
         # TODO: Same here
-        eeLabels = ee.List(labels).flatten() if labels else eeBands
+        eeLabels = ee.List(labels).flatten() if labels is None else eeBands
         new_labels: list[str] = eeLabels.getInfo()
-        new_colors: list[str] = colors if colors else plt.get_cmap("tab10").colors
+        new_colors: list[str] = colors if colors is None else plt.get_cmap("tab10").colors
 
         # retrieve the region from the parameters
-        region = region if region else self._obj.geometry()
+        region = region if region is None else self._obj.geometry()
 
         # extract the data from the server
         image = self._obj.select(eeBands).rename(eeLabels).clip(region)

--- a/geetools/ee_image_collection.py
+++ b/geetools/ee_image_collection.py
@@ -669,7 +669,7 @@ class ImageCollectionAccessor:
         """
         # cast parameters and compute the outlier band names
         initBands = self._obj.first().bandNames()
-        statBands = ee.List(bands) if bands else initBands
+        statBands = ee.List(bands) if bands is None else initBands
         outBands = statBands.map(lambda b: ee.String(b).cat("_outlier"))
 
         # compute the mean and std dev for each band
@@ -1214,8 +1214,8 @@ class ImageCollectionAccessor:
                 print(reduced.getInfo())
         """
         # cast parameters
-        eeBands = ee.List(bands) if bands else self._obj.first().bandNames()
-        eeLabels = ee.List(labels) if labels else eeBands
+        eeBands = ee.List(bands) if bands is None else self._obj.first().bandNames()
+        eeLabels = ee.List(labels) if labels is None else eeBands
 
         # recast band names as labels in the source collection
         ic = self._obj.select(eeBands).map(lambda i: i.rename(eeLabels))
@@ -1384,8 +1384,8 @@ class ImageCollectionAccessor:
             - :docstring:`ee.ImageCollection.geetools.plot_doy_by_years`
         """
         # cast parameters
-        bands = ee.List(bands) if bands else self._obj.first().bandNames()
-        labels = ee.List(labels) if labels else bands
+        bands = ee.List(bands) if bands is None else self._obj.first().bandNames()
+        labels = ee.List(labels) if labels is None else bands
 
         # recast band names as labels in the source collection
         ic = self._obj.select(bands).map(lambda i: i.rename(labels))

--- a/geetools/ee_image_collection.py
+++ b/geetools/ee_image_collection.py
@@ -669,7 +669,7 @@ class ImageCollectionAccessor:
         """
         # cast parameters and compute the outlier band names
         initBands = self._obj.first().bandNames()
-        statBands = ee.List(bands) if bands is None else initBands
+        statBands = ee.List(bands) if bands is not None else initBands
         outBands = statBands.map(lambda b: ee.String(b).cat("_outlier"))
 
         # compute the mean and std dev for each band
@@ -1214,8 +1214,8 @@ class ImageCollectionAccessor:
                 print(reduced.getInfo())
         """
         # cast parameters
-        eeBands = ee.List(bands) if bands is None else self._obj.first().bandNames()
-        eeLabels = ee.List(labels) if labels is None else eeBands
+        eeBands = ee.List(bands) if bands is not None else self._obj.first().bandNames()
+        eeLabels = ee.List(labels) if labels is not None else eeBands
 
         # recast band names as labels in the source collection
         ic = self._obj.select(eeBands).map(lambda i: i.rename(eeLabels))
@@ -1384,8 +1384,8 @@ class ImageCollectionAccessor:
             - :docstring:`ee.ImageCollection.geetools.plot_doy_by_years`
         """
         # cast parameters
-        bands = ee.List(bands) if bands is None else self._obj.first().bandNames()
-        labels = ee.List(labels) if labels is None else bands
+        bands = ee.List(bands) if bands is not None else self._obj.first().bandNames()
+        labels = ee.List(labels) if labels is not None else bands
 
         # recast band names as labels in the source collection
         ic = self._obj.select(bands).map(lambda i: i.rename(labels))

--- a/geetools/ee_image_collection.py
+++ b/geetools/ee_image_collection.py
@@ -7,6 +7,12 @@ from typing import Any, Iterable
 
 import ee
 import ee_extra
+import ee_extra.Algorithms.core
+import ee_extra.ImageCollection.core
+import ee_extra.QA.clouds
+import ee_extra.QA.pipelines
+import ee_extra.Spectral.core
+import ee_extra.STAC.core
 import requests
 import xarray
 from ee import apifunction
@@ -127,7 +133,7 @@ class ImageCollectionAccessor:
 
     def spectralIndices(
         self,
-        index: str = "NDVI",
+        index: str | list[str] = "NDVI",
         G: float | int = 2.5,
         C1: float | int = 6.0,
         C2: float | int = 7.5,
@@ -611,7 +617,10 @@ class ImageCollectionAccessor:
         return ee.Image(self._obj.iterate(computeIntegral, s))
 
     def outliers(
-        self, bands: list | ee.List = [], sigma: float | int | ee.Number = 2, drop: bool = False
+        self,
+        bands: list[str] | ee.List | None = None,
+        sigma: float | int | ee.Number = 2,
+        drop: bool = False,
     ) -> ee.ImageCollection:
         """Compute the outlier for each pixel in the specified bands.
 
@@ -784,12 +793,12 @@ class ImageCollectionAccessor:
         validPct = validPixel.divide(self._obj.size()).multiply(100).rename("pct_valid")
         return validPixel.addBands(validPct)
 
-    def containsBandNames(self, bandNames: list | ee.List, filter: str) -> ee.ImageCollection:
+    def containsBandNames(self, bandNames: list[str] | ee.List, filter: str) -> ee.ImageCollection:
         """Filter the :py:class:`ee.ImageCollection` by band names using the provided filter.
 
         Args:
-            bandNames: list of band names to filter
-            filter: type of filter to apply. To keep images that contains all the specified bands use ``"ALL"``. To get the images including at least one of the specified band use ``"ANY"``.
+            bandNames: List of band names to filter.
+            filter: Type of filter to apply. To keep images that contains all the specified bands use ``"ALL"``. To get the images including at least one of the specified band use ``"ANY"``.
 
         Returns:
             A filtered :py:class:`ee.ImageCollection`
@@ -829,11 +838,11 @@ class ImageCollectionAccessor:
 
         return ee.ImageCollection(ic)
 
-    def containsAllBands(self, bandNames: list | ee.List) -> ee.ImageCollection:
+    def containsAllBands(self, bandNames: list[str] | ee.List) -> ee.ImageCollection:
         """Filter the :py:class:`ee.ImageCollection` keeping only the images with all the provided bands.
 
         Args:
-            bandNames: list of band names to filter
+            bandNames: List of band names to filter.
 
         Returns:
             A filtered :py:class:`ee.ImageCollection`
@@ -856,11 +865,11 @@ class ImageCollectionAccessor:
         """
         return self.containsBandNames(bandNames, "ALL")
 
-    def containsAnyBands(self, bandNames: list | ee.List) -> ee.ImageCollection:
+    def containsAnyBands(self, bandNames: list[str] | ee.List) -> ee.ImageCollection:
         """Filter the :py:class:`ee.ImageCollection` keeping only the images with any of the provided bands.
 
         Args:
-            bandNames: list of band names to filter
+            bandNames: List of band names to filter.
 
         Returns:
             A filtered :py:class:`ee.ImageCollection`
@@ -883,11 +892,11 @@ class ImageCollectionAccessor:
         """
         return self.containsBandNames(bandNames, "ANY")
 
-    def aggregateArray(self, properties: list | ee.List | None = None) -> ee.Dictionary:
+    def aggregateArray(self, properties: list[str] | ee.List | None = None) -> ee.Dictionary:
         """Aggregate the :py:class:`ee.ImageCollection` selected properties into a dictionary.
 
         Args:
-            properties: list of properties to aggregate. If None, all properties are aggregated.
+            properties: List of properties to aggregate. If None, all properties are aggregated.
 
         Returns:
             A dictionary with the properties as keys and the aggregated values as values.
@@ -1145,8 +1154,8 @@ class ImageCollectionAccessor:
         region: ee.Geometry,
         reducer: str | ee.Reducer = "mean",
         dateProperty: str = "system:time_start",
-        bands: list = [],
-        labels: list = [],
+        bands: list[str] | None = None,
+        labels: list[str] | None = None,
         scale: int = 10000,
         crs: str | None = None,
         crsTransform: list | None = None,
@@ -1205,8 +1214,8 @@ class ImageCollectionAccessor:
                 print(reduced.getInfo())
         """
         # cast parameters
-        eeBands = ee.List(bands) if len(bands) else self._obj.first().bandNames()
-        eeLabels = ee.List(labels) if len(labels) else eeBands
+        eeBands = ee.List(bands) if bands else self._obj.first().bandNames()
+        eeLabels = ee.List(labels) if labels else eeBands
 
         # recast band names as labels in the source collection
         ic = self._obj.select(eeBands).map(lambda i: i.rename(eeLabels))
@@ -1327,8 +1336,8 @@ class ImageCollectionAccessor:
         spatialReducer: str | ee.Reducer = "mean",
         timeReducer: str | ee.Reducer = "mean",
         dateProperty: str = "system:time_start",
-        bands: list = [],
-        labels: list = [],
+        bands: list[str] | None = None,
+        labels: list[str] | None = None,
         scale: int = 10000,
         crs: str | None = None,
         crsTransform: list | None = None,
@@ -1375,8 +1384,8 @@ class ImageCollectionAccessor:
             - :docstring:`ee.ImageCollection.geetools.plot_doy_by_years`
         """
         # cast parameters
-        bands = ee.List(bands) if len(bands) else self._obj.first().bandNames()
-        labels = ee.List(labels) if len(labels) else bands
+        bands = ee.List(bands) if bands else self._obj.first().bandNames()
+        labels = ee.List(labels) if labels else bands
 
         # recast band names as labels in the source collection
         ic = self._obj.select(bands).map(lambda i: i.rename(labels))
@@ -1407,7 +1416,7 @@ class ImageCollectionAccessor:
             getattr(ee.Reducer, timeReducer)() if isinstance(timeReducer, str) else timeReducer
         )
 
-        def timeReduce(c: ee.imageCollection) -> ee.image:
+        def timeReduce(c: ee.ImageCollection) -> ee.image:
             c = ee.ImageCollection(c)
             i = c.reduce(timeRed).rename(labels)
             i = i.set(size_metadata, c.get(size_metadata))
@@ -1513,7 +1522,7 @@ class ImageCollectionAccessor:
             getattr(ee.Reducer, timeReducer)() if isinstance(timeReducer, str) else timeReducer
         )
 
-        def timeReduce(c: ee.imageCollection) -> ee.image:
+        def timeReduce(c: ee.ImageCollection) -> ee.image:
             c = ee.ImageCollection(c)
             i = c.reduce(timeRed).rename([band])
             i = i.set(size_metadata, c.get(size_metadata))
@@ -1771,9 +1780,9 @@ class ImageCollectionAccessor:
         region: ee.Geometry,
         reducer: str | ee.Reducer = "mean",
         dateProperty: str = "system:time_start",
-        bands: list = [],
-        labels: list = [],
-        colors: list = [],
+        bands: list[str] | None = None,
+        labels: list[str] | None = None,
+        colors: list[str] | None = None,
         ax: Axes | None = None,
         scale: int = 10000,
         crs: str | None = None,
@@ -1863,7 +1872,7 @@ class ImageCollectionAccessor:
         label: str = "system:index",
         reducer: str | ee.Reducer = "mean",
         dateProperty: str = "system:time_start",
-        colors: list = [],
+        colors: list[str] | None = None,
         ax: Axes | None = None,
         scale: int = 10000,
         crs: str | None = None,
@@ -1949,9 +1958,9 @@ class ImageCollectionAccessor:
         spatialReducer: str | ee.Reducer = "mean",
         timeReducer: str | ee.Reducer = "mean",
         dateProperty: str = "system:time_start",
-        bands: list = [],
-        labels: list = [],
-        colors: list = [],
+        bands: list[str] | None = None,
+        labels: list[str] | None = None,
+        colors: list[str] | None = None,
         ax: Axes | None = None,
         scale: int = 10000,
         crs: str | None = None,
@@ -2043,7 +2052,7 @@ class ImageCollectionAccessor:
         spatialReducer: str | ee.Reducer = "mean",
         timeReducer: str | ee.Reducer = "mean",
         dateProperty: str = "system:time_start",
-        colors: list = [],
+        colors: list[str] | None = None,
         ax: Axes | None = None,
         scale: int = 10000,
         crs: str | None = None,
@@ -2133,7 +2142,7 @@ class ImageCollectionAccessor:
         seasonEnd: int | ee.Number,
         reducer: str | ee.Reducer = "mean",
         dateProperty: str = "system:time_start",
-        colors: list = [],
+        colors: list[str] | None = None,
         ax: Axes | None = None,
         scale: int = 10000,
         crs: str | None = None,
@@ -2240,7 +2249,7 @@ class ImageCollectionAccessor:
         region: ee.Geometry,
         reducer: str | ee.Reducer = "mean",
         dateProperty: str = "system:time_start",
-        colors: list = [],
+        colors: list[str] | None = None,
         ax: Axes | None = None,
         scale: int = 10000,
         crs: str | None = None,

--- a/geetools/ee_initialize.py
+++ b/geetools/ee_initialize.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import os
 import tempfile
 from pathlib import Path
 
@@ -20,7 +21,7 @@ class InitializeAccessor:
     """Toolbox for the ``ee.Initialize`` function."""
 
     @staticmethod
-    def from_user(name: str = "", credential_pathname: str | Path = "", project: str = "") -> None:
+    def from_user(name: str = "", credential_pathname: str | os.PathLike = "", project: str = ""):
         """Initialize Earthengine API using a specific user.
 
         Equivalent to the :py:func:`ee.Initialize` function but with a specific credential file stored in
@@ -71,7 +72,7 @@ class InitializeAccessor:
         _project_id = project or tokens["project_id"]
 
     @staticmethod
-    def from_service_account(private_key: str) -> None:
+    def from_service_account(private_key: str):
         """Initialize Earthengine API using a service account.
 
         Equivalent to the :py:func:`ee.Initialize` function but with a specific service account json key.

--- a/geetools/ee_initialize.py
+++ b/geetools/ee_initialize.py
@@ -20,7 +20,7 @@ class InitializeAccessor:
     """Toolbox for the ``ee.Initialize`` function."""
 
     @staticmethod
-    def from_user(name: str = "", credential_pathname: str = "", project: str = "") -> None:
+    def from_user(name: str = "", credential_pathname: str | Path = "", project: str = "") -> None:
         """Initialize Earthengine API using a specific user.
 
         Equivalent to the :py:func:`ee.Initialize` function but with a specific credential file stored in

--- a/geetools/utils.py
+++ b/geetools/utils.py
@@ -74,7 +74,7 @@ def plot_data(
     type: str,
     data: dict,
     label_name: str,
-    colors: list = [],
+    colors: list[str] | None = None,
     ax: Axes | None = None,
     **kwargs,
 ) -> Axes:
@@ -242,7 +242,7 @@ def plot_data(
     return ax
 
 
-def initialize_documentation():
+def initialize_documentation() -> None:
     """Initialize Earth Engine Python API in the context of the Documentation build.
 
     Warning:

--- a/geetools/utils.py
+++ b/geetools/utils.py
@@ -242,7 +242,7 @@ def plot_data(
     return ax
 
 
-def initialize_documentation() -> None:
+def initialize_documentation():
     """Initialize Earth Engine Python API in the context of the Documentation build.
 
     Warning:


### PR DESCRIPTION
With respect the PR #409 

> > Some methods uses mutable parameters, for example
> 
> We realized that wih Rodrigo some time ago, I would suggest to do it in a follow-up PR

I mentioned that are many mutable parameters. This is the follow-up PR to fix it.

The changes are:

* Improve typing: The list are more specific and the paths can be a Path instance.
* Drop mutable default arguments: Replace empty list with Nones
* Convert a method in static if the method doesn't use anything.