### PR TITLE
add timezone to ee.Date conversion to datetime

### DIFF
--- a/geetools/ee_date.py
+++ b/geetools/ee_date.py
@@ -96,7 +96,7 @@ class DateAccessor:
         the timezone from it, thus it must be passed as argument.
 
         Args:
-            tz: time zone. Defaults to UTC.
+            tz: time zone, defaulted to "UTC". Other names can be found here: https://www.joda.org/joda-time/timezones.html
 
         Returns:
             The :py:class:`datetime.datetime` representation of the :py:class:`ee.Date`.

--- a/geetools/ee_date.py
+++ b/geetools/ee_date.py
@@ -1,8 +1,8 @@
 """Extra methods for the :py:class:`ee.Date` class."""
 from __future__ import annotations
 
-import zoneinfo
 from datetime import datetime
+from zoneinfo import ZoneInfo
 
 import ee
 
@@ -89,7 +89,7 @@ class DateAccessor:
         """
         return ee.Date(datetime.now().isoformat())
 
-    def to_datetime(self, tz=zoneinfo.ZoneInfo("UTC")) -> datetime:
+    def to_datetime(self, tz: str | ZoneInfo = ZoneInfo("UTC")) -> datetime:
         """Convert a :py:class:`ee.Date` to a :py:class:`datetime.datetime`.
 
         Since `ee.Date` object is not timezone aware, there is no way to get
@@ -113,8 +113,9 @@ class DateAccessor:
                 d.strftime('%Y-%m-%d')
 
         """
-        datestr = self._obj.format(None, str(tz)).getInfo()
-        return datetime.fromisoformat(datestr)
+        tz = tz if isinstance(tz, ZoneInfo) else ZoneInfo(tz)
+        timestamp = self._obj.millis().getInfo() / 1000
+        return datetime.fromtimestamp(timestamp, tz=ZoneInfo("UTC")).astimezone(tz)
 
     def getUnitSinceEpoch(self, unit: str = "day") -> ee.Number:
         """Get the number of units since epoch (1970-01-01).

--- a/geetools/ee_date.py
+++ b/geetools/ee_date.py
@@ -1,6 +1,7 @@
 """Extra methods for the :py:class:`ee.Date` class."""
 from __future__ import annotations
 
+import zoneinfo
 from datetime import datetime
 
 import ee
@@ -88,8 +89,14 @@ class DateAccessor:
         """
         return ee.Date(datetime.now().isoformat())
 
-    def to_datetime(self) -> datetime:
+    def to_datetime(self, tz=zoneinfo.ZoneInfo("UTC")) -> datetime:
         """Convert a :py:class:`ee.Date` to a :py:class:`datetime.datetime`.
+
+        Since `ee.Date` object is not timezone aware, there is no way to get
+        the timezone from it, thus it must be passed as argument.
+
+        Args:
+            tz: time zone. Defaults to UTC.
 
         Returns:
             The :py:class:`datetime.datetime` representation of the :py:class:`ee.Date`.
@@ -106,7 +113,8 @@ class DateAccessor:
                 d.strftime('%Y-%m-%d')
 
         """
-        return datetime.fromtimestamp(self._obj.millis().getInfo() / 1000.0)
+        datestr = self._obj.format(None, str(tz)).getInfo()
+        return datetime.fromisoformat(datestr)
 
     def getUnitSinceEpoch(self, unit: str = "day") -> ee.Number:
         """Get the number of units since epoch (1970-01-01).

--- a/tests/test_Date.py
+++ b/tests/test_Date.py
@@ -14,6 +14,14 @@ class TestToDatetime:
         assert datetime.month == 1
         assert datetime.day == 1
 
+    def test_to_datetime_timezone(self, date_instance):
+        dt = date_instance.geetools.to_datetime("America/Buenos_Aires")
+        # Buenos Aires time is -3
+        assert dt.year == 2019
+        assert dt.month == 12
+        assert dt.day == 31
+        assert dt.hour == 21
+
 
 class TestGetUnitSinceEpoch:
     """Test the getUnitSinceEpoch method."""

--- a/tests/test_Date.py
+++ b/tests/test_Date.py
@@ -1,4 +1,7 @@
 """Test the Date class methods."""
+from datetime import datetime as dt
+from zoneinfo import ZoneInfo
+
 import ee
 import pytest
 
@@ -9,18 +12,20 @@ class TestToDatetime:
     """Test the toDatetime method."""
 
     def test_to_datetime(self, date_instance):
-        datetime = date_instance.geetools.to_datetime()
-        assert datetime.year == 2020
-        assert datetime.month == 1
-        assert datetime.day == 1
+        py_dt = date_instance.geetools.to_datetime()
+        assert py_dt == dt(2020, 1, 1, tzinfo=ZoneInfo("UTC"))
 
     def test_to_datetime_timezone(self, date_instance):
-        dt = date_instance.geetools.to_datetime("America/Buenos_Aires")
+        tz = ZoneInfo("America/Buenos_Aires")
+        py_dt = date_instance.geetools.to_datetime(tz)
         # Buenos Aires time is -3
-        assert dt.year == 2019
-        assert dt.month == 12
-        assert dt.day == 31
-        assert dt.hour == 21
+        assert py_dt == dt(2019, 12, 31, 21, tzinfo=tz)
+
+    def test_to_datetime_str_timezone(self, date_instance):
+        str_tz = "America/Buenos_Aires"
+        py_dt = date_instance.geetools.to_datetime(str_tz)
+        # Buenos Aires time is -3
+        assert py_dt == dt(2019, 12, 31, 21, tzinfo=ZoneInfo(str_tz))
 
 
 class TestGetUnitSinceEpoch:


### PR DESCRIPTION
Luckily I live in a different time zone than UTC and tests for this method was failing due to it.

I follow the GEE pattern as `ee.Date.format` method, to which user can pass a time zone and get the formatted representation of that date in the specified time zone (https://code.earthengine.google.com/91d328471a218815afda4309021dc68a)