### PR TITLE
`ee.List` chunks

### DIFF
--- a/tests/test_List.py
+++ b/tests/test_List.py
@@ -1,6 +1,8 @@
 """Test the List class methods."""
 import ee
 
+import geetools  # noqa:F401
+
 
 class TestProduct:
     """Test the product method."""
@@ -112,3 +114,17 @@ class TestJoin:
     def test_join_with_separator(self, mix_list):
         formatted = mix_list.geetools.join(separator="; ")
         assert formatted.getInfo() == "a; 1; Image"
+
+
+class TestChunked:
+    """Test the chunked method."""
+
+    def test_chunked_even(self):
+        input = ee.List([1, 2, 3, 4, 5, 6, 7, 8, 9])
+        chunked = input.geetools.chunked(3)
+        assert chunked.getInfo() == [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+
+    def test_chunked_odd(self):
+        input = ee.List([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        chunked = input.geetools.chunked(3)
+        assert chunked.getInfo() == [[1, 2, 3], [4, 5, 6], [7, 8, 9, 10]]


### PR DESCRIPTION
This is a pretty common procedure in programming, but it involves some decisions that I took by myself, but I'm open to suggestions.

The main decision is how to handle the odd lists. In this PR, the "rest" is going to the last chunk. Other options could be:

- the "rest" goes to the first chunk
- each element of the "rest" goes to a different chunk

Also, this could be decided by a param, but I didn't want to add to much complexity in the first version.

The workaround used to avoid using `ee.Algorithms.If` if totally open to discussion.