### PR TITLE
feat: add year agnostic doy capacity

### DIFF
--- a/tests/test_Date.py
+++ b/tests/test_Date.py
@@ -64,10 +64,21 @@ class TestFromDOY:
         date = ee.Date.geetools.fromDOY(1, 3)
         assert date.format("YYYY-MM-DD").getInfo() == "0003-01-01"
 
-    def test_wrong_doy(self):
-        # check that GEE can use > 365 doy
-        date = ee.Date.geetools.fromDOY(367, 2020)
-        assert date.format("YYYY-MM-DD").getInfo() == "2021-01-01"
+
+class TestToDOY:
+    """Test the toDOY method."""
+
+    def test_to_doy(self):
+        doy = ee.Date("2025-04-09").geetools.toDOY()
+        assert doy.getInfo() == 99
+
+    def test_to_doy_leap(self):
+        doy = ee.Date("2020-03-01").geetools.toDOY()
+        assert doy.getInfo() == 60
+
+    def test_to_doy_non_leap(self):
+        doy = ee.Date("2021-03-01").geetools.toDOY()
+        assert doy.getInfo() == 60
 
 
 class TestIsLeap:


### PR DESCRIPTION
Everything is in the title. 

- The `toDOY` method is transforming any doy value into it's corresponding 0 -365 range equivalent. the 60th day (29th of february) will only appear during leap year.
- The `fromDOY` ethod will now only expect this type of entry to generate a date. 

Tests have been updated accodingly. 

This feature is needed for imagecollection plotting and year to year  (eason to season) comparaisons. 