### PR TITLE
get name of 'columns' from a FeatureCollection

### DIFF
--- a/geetools/ee_feature_collection.py
+++ b/geetools/ee_feature_collection.py
@@ -226,6 +226,12 @@ class FeatureCollectionAccessor:
         union = self._obj.iterate(lambda f, g: f.geometry().union(g, maxError=maxError), first)
         return ee.Geometry(union).dissolve(maxError=maxError)
 
+    def columnNames(self) -> ee.List:
+        """Get the name of the columns (Feature's properties)."""
+        temp_property_name = "__geetools_properties__"
+        fc = self._obj.map(lambda feat: feat.set(temp_property_name, feat.propertyNames()))
+        return fc.aggregate_array(temp_property_name).flatten().distinct()
+
     def toPolygons(self) -> ee.FeatureCollection:
         """Drop any geometry that is not a Polygon or a multipolygon.
 

--- a/geetools/ee_feature_collection.py
+++ b/geetools/ee_feature_collection.py
@@ -330,9 +330,9 @@ class FeatureCollectionAccessor:
         values = eeProps.map(lambda p: ee.Dictionary.fromLists(feats, self._obj.aggregate_array(p)))
 
         # get the label to use in the dictionary if requested
-        labels = ee.List(labels) if labels is not None else properties
+        eeLabels = eeProps if labels is None else ee.List(labels)
 
-        return ee.Dictionary.fromLists(labels, values)
+        return ee.Dictionary.fromLists(eeLabels, values)
 
     def byFeatures(
         self,

--- a/tests/test_FeatureCollection.py
+++ b/tests/test_FeatureCollection.py
@@ -59,6 +59,42 @@ class TestAddId:
         return ee.FeatureCollection("FAO/GAUL/2015/level0").limit(10)
 
 
+class TestColumnNames:
+    """Test the ``columnNames`` method."""
+
+    def test_column_names(self, fc_instance, ee_list_regression):
+        columns = fc_instance.geetools.columnNames()
+        ee_list_regression.check(columns)
+
+    @pytest.fixture
+    def fc_instance(self):
+        geometry = ee.Geometry.Polygon(
+            [
+                [
+                    [-111.108203125, 38.72726135581648],
+                    [-111.108203125, 34.42385763998893],
+                    [-106.362109375, 34.42385763998893],
+                    [-106.362109375, 38.72726135581648],
+                ]
+            ]
+        )
+        image = ee.Image.random().clip(geometry)
+        fc = ee.FeatureCollection(
+            [
+                ee.Feature(
+                    ee.Geometry.Point([-101.1765625, 35.71859799956555]), {"system:index": "0"}
+                ),
+                ee.Feature(
+                    ee.Geometry.Point([-106.186328125, 41.41694364515647]), {"system:index": "1"}
+                ),
+                ee.Feature(
+                    ee.Geometry.Point([-108.471484375, 37.132906371577455]), {"system:index": "2"}
+                ),
+            ]
+        )
+        return image.reduceRegions(collection=fc, reducer=ee.Reducer.first(), scale=1000)
+
+
 class TestMergeGeometries:
     """Test the ``mergeGeometries`` method."""
 

--- a/tests/test_FeatureCollection.py
+++ b/tests/test_FeatureCollection.py
@@ -81,15 +81,9 @@ class TestColumnNames:
         image = ee.Image.random().clip(geometry)
         fc = ee.FeatureCollection(
             [
-                ee.Feature(
-                    ee.Geometry.Point([-101.1765625, 35.71859799956555]), {"system:index": "0"}
-                ),
-                ee.Feature(
-                    ee.Geometry.Point([-106.186328125, 41.41694364515647]), {"system:index": "1"}
-                ),
-                ee.Feature(
-                    ee.Geometry.Point([-108.471484375, 37.132906371577455]), {"system:index": "2"}
-                ),
+                ee.Feature(ee.Geometry.Point([-101.1765625, 35.71859799956555]), {"system:index": "0"}),
+                ee.Feature(ee.Geometry.Point([-106.186328125, 41.41694364515647]), {"system:index": "1"}),
+                ee.Feature(ee.Geometry.Point([-108.471484375, 37.132906371577455]), {"system:index": "2"}),
             ]
         )
         return image.reduceRegions(collection=fc, reducer=ee.Reducer.first(), scale=1000)

--- a/tests/test_FeatureCollection/serialized_test_column_names.yml
+++ b/tests/test_FeatureCollection/serialized_test_column_names.yml
@@ -1,0 +1,124 @@
+result: '0'
+values:
+  '0':
+    functionInvocationValue:
+      arguments:
+        list:
+          functionInvocationValue:
+            arguments:
+              list:
+                functionInvocationValue:
+                  arguments:
+                    collection:
+                      functionInvocationValue:
+                        arguments:
+                          baseAlgorithm:
+                            functionDefinitionValue:
+                              argumentNames:
+                              - _MAPPING_VAR_0_0
+                              body: '1'
+                          collection:
+                            functionInvocationValue:
+                              arguments:
+                                collection:
+                                  functionInvocationValue:
+                                    arguments:
+                                      features:
+                                        arrayValue:
+                                          values:
+                                          - functionInvocationValue:
+                                              arguments:
+                                                geometry:
+                                                  functionInvocationValue:
+                                                    arguments:
+                                                      coordinates:
+                                                        constantValue:
+                                                        - -101.1765625
+                                                        - 35.71859799956555
+                                                    functionName: GeometryConstructors.Point
+                                                metadata:
+                                                  constantValue:
+                                                    system:index: '0'
+                                              functionName: Feature
+                                          - functionInvocationValue:
+                                              arguments:
+                                                geometry:
+                                                  functionInvocationValue:
+                                                    arguments:
+                                                      coordinates:
+                                                        constantValue:
+                                                        - -106.186328125
+                                                        - 41.41694364515647
+                                                    functionName: GeometryConstructors.Point
+                                                metadata:
+                                                  constantValue:
+                                                    system:index: '1'
+                                              functionName: Feature
+                                          - functionInvocationValue:
+                                              arguments:
+                                                geometry:
+                                                  functionInvocationValue:
+                                                    arguments:
+                                                      coordinates:
+                                                        constantValue:
+                                                        - -108.471484375
+                                                        - 37.132906371577455
+                                                    functionName: GeometryConstructors.Point
+                                                metadata:
+                                                  constantValue:
+                                                    system:index: '2'
+                                              functionName: Feature
+                                    functionName: Collection
+                                image:
+                                  functionInvocationValue:
+                                    arguments:
+                                      geometry:
+                                        functionInvocationValue:
+                                          arguments:
+                                            coordinates:
+                                              constantValue:
+                                              - - - -111.108203125
+                                                  - 38.72726135581648
+                                                - - -111.108203125
+                                                  - 34.42385763998893
+                                                - - -106.362109375
+                                                  - 34.42385763998893
+                                                - - -106.362109375
+                                                  - 38.72726135581648
+                                            evenOdd:
+                                              constantValue: true
+                                          functionName: GeometryConstructors.Polygon
+                                      input:
+                                        functionInvocationValue:
+                                          arguments: {}
+                                          functionName: Image.random
+                                    functionName: Image.clip
+                                reducer:
+                                  functionInvocationValue:
+                                    arguments: {}
+                                    functionName: Reducer.first
+                                scale:
+                                  constantValue: 1000
+                              functionName: Image.reduceRegions
+                        functionName: Collection.map
+                    property:
+                      valueReference: '2'
+                  functionName: AggregateFeatureCollection.array
+            functionName: List.flatten
+      functionName: List.distinct
+  '1':
+    functionInvocationValue:
+      arguments:
+        key:
+          valueReference: '2'
+        object:
+          argumentReference: _MAPPING_VAR_0_0
+        value:
+          functionInvocationValue:
+            arguments:
+              element:
+                argumentReference: _MAPPING_VAR_0_0
+            functionName: Element.propertyNames
+      functionName: Element.set
+  '2':
+    constantValue: __geetools_properties__

--- a/tests/test_FeatureCollection/test_column_names.yml
+++ b/tests/test_FeatureCollection/test_column_names.yml
@@ -1,0 +1,2 @@
+- system:index
+- first


### PR DESCRIPTION
Sometime all `Feature` from a `FeatureCollection` do not contain the same properties, thus getting the "column" names is unintuitive, because this doesn't work: `fc.first().propertyNames()` and we might not want to call `getInfo`.

The test is showing a clear example on when this happens and proves that this method manages to get all column names.