### PR TITLE
fix: data can be a float as well

### DIFF
--- a/geetools/ee_asset.py
+++ b/geetools/ee_asset.py
@@ -775,11 +775,11 @@ class Asset(os.PathLike):
         """
         # time_start and time_end are only supporting the "str" format which is inconsistent with the API
         # return statement. To comply with a user expectation, we will do the conversions on our side.
-        def date_in_str(d: str | int | datetime | date) -> str:
+        def date_in_str(d: str | int | float | datetime | date) -> str:
             if isinstance(d, (datetime, date)):
                 d = d.isoformat() + "Z"  # add the Z to indicate UTC time as EE don't read ISO
-            elif isinstance(d, int):
-                d = datetime.fromtimestamp(d / 1000).isoformat() + "Z"
+            elif isinstance(d, (int, float)):
+                d = datetime.fromtimestamp(int(d) / 1000).isoformat() + "Z"
             return str(d)  # if any other format is used, we will simply return it as a string
 
         if "system:start_time" in kwargs:


### PR DESCRIPTION
everything is in the title THis was not working because number from GEE are always interpreted as floats: 

```python 
ic = ee.ImageCollection(collection.as_posix())
collection.setProperties(**{
    "system:time_start": ic.aggregate_min("system:time_start").getInfo(),
    "system:time_end": ic.aggregate_max("system:time_start").getInfo(),
})
```

This PR should make sure the numbers are alwaysinterpreted as timestamps and transformed into str isoformated dates